### PR TITLE
fix: ajout du port pour scalingo

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start",
+    "start": "next start -p $PORT",
     "lint": "next lint",
     "test": "jest --config jest.config.js",
     "test:watch": "jest --config jest.config.js --watch"


### PR DESCRIPTION
ajout du port pour le script de build de scalingo. 
voir la doc : https://doc.scalingo.com/languages/nodejs/start#nextjs