### PR TITLE
fix: Ajout du jeune dans le model rdv pour l afficher correctement

### DIFF
--- a/components/rdv/DeleteRdvModal.tsx
+++ b/components/rdv/DeleteRdvModal.tsx
@@ -63,8 +63,9 @@ const DeleteRdvModal = ({
           customWidth='800px'
         >
           <p className='text-md text-bleu_nuit mb-[48px]'>
-            Souhaitez-vous vraiment supprimer votre rendez-vous avec {rdv.title}{' '}
-            le {formatDayDate(new Date(rdv.date))}?
+            Souhaitez-vous vraiment supprimer votre rendez-vous avec{' '}
+            {rdv.jeune.prenom} {rdv.jeune.nom} le
+            {formatDayDate(new Date(rdv.date))}?
           </p>
 
           <div className='flex'>

--- a/components/rdv/RdvList.test.tsx
+++ b/components/rdv/RdvList.test.tsx
@@ -21,9 +21,8 @@ describe('<RdvList>', () => {
     render(<RdvList rdvs={listeRdv} />)
 
     expect(screen.getByText('21/10/2021 (10:00 - 30 min)')).toBeInTheDocument()
-    expect(screen.getByText('Rama')).toBeInTheDocument()
-    expect(screen.getByText('Par téléphone')).toBeInTheDocument()
-    expect(screen.getByText('Rendez-vous avec Rama')).toBeInTheDocument()
+    expect(screen.getByText(listeRdv[0].modality)).toBeInTheDocument()
+    expect(screen.getByText(listeRdv[0].comment)).toBeInTheDocument()
   })
 
   it('ne devrait pas afficher un tableau de rdvs quand rdvs est vide', () => {

--- a/components/rdv/RdvList.test.tsx
+++ b/components/rdv/RdvList.test.tsx
@@ -22,6 +22,9 @@ describe('<RdvList>', () => {
 
     expect(screen.getByText('21/10/2021 (10:00 - 30 min)')).toBeInTheDocument()
     expect(screen.getByText(listeRdv[0].modality)).toBeInTheDocument()
+    expect(
+      screen.getByText(`${listeRdv[0].jeune.prenom} ${listeRdv[0].jeune.nom}`)
+    ).toBeInTheDocument()
     expect(screen.getByText(listeRdv[0].comment)).toBeInTheDocument()
   })
 

--- a/components/rdv/RdvList.tsx
+++ b/components/rdv/RdvList.tsx
@@ -50,7 +50,7 @@ const RdvList = ({ rdvs, onDelete }: RdvListProps) => {
                 </td>
 
                 <td className='p-[16px]'>
-                  {rdv.jeune.prenom} {rdv.jeune.prenom}
+                  {rdv.jeune.prenom} {rdv.jeune.nom}
                 </td>
 
                 <td className='p-[16px] '>

--- a/components/rdv/RdvList.tsx
+++ b/components/rdv/RdvList.tsx
@@ -49,7 +49,9 @@ const RdvList = ({ rdvs, onDelete }: RdvListProps) => {
                   {dayHourCells(new Date(rdv.date), rdv.duration)}
                 </td>
 
-                <td className='p-[16px]'>{rdv.title}</td>
+                <td className='p-[16px]'>
+                  {rdv.jeune.prenom} {rdv.jeune.prenom}
+                </td>
 
                 <td className='p-[16px] '>
                   <LocationIcon

--- a/fixtures/rendez-vous.ts
+++ b/fixtures/rendez-vous.ts
@@ -4,19 +4,27 @@ export const uneListeDeRdv = (overrides: Partial<Rdv[]> = []): Rdv[] =>
   [
     {
       id: '1',
-      title: 'Rama',
-      comment: 'Rendez-vous avec Rama',
+      comment: 'Rendez-vous avec Kenji',
       date: 'Thu, 21 Oct 2021 10:00:00 GMT',
       duration: '30 min',
       modality: 'Par téléphone',
+      jeune: {
+        id: '1',
+        prenom: 'kenji',
+        nom: 'Jirac',
+      },
     },
     {
       id: '2',
-      title: 'Sixtine',
       comment: 'Mon premier rendez-vous',
       date: 'Mon, 25 Oct 2021 12:00:00 GMT',
       duration: '25 min',
       modality: 'En agence',
+      jeune: {
+        id: '1',
+        prenom: 'kenji',
+        nom: 'Jirac',
+      },
     },
     ...overrides,
   ] as Rdv[]
@@ -29,13 +37,23 @@ export const uneListeDeRdvJeune = (overrides: RdvJeune[] = []): RdvJeune[] =>
       date: 'Mon, 25 Oct 2021 07:00:00 GMT',
       duration: '25',
       modality: 'En agence',
+      jeune: {
+        id: '1',
+        prenom: 'kenji',
+        nom: 'Jirac',
+      },
     },
     {
       id: '2',
-      comment: 'Rendez-vous avec Rama',
+      comment: 'Rendez-vous avec Kenji',
       date: 'Thu, 21 Oct 2021 07:00:00 GMT',
       duration: '30',
       modality: 'Par téléphone',
+      jeune: {
+        id: '1',
+        prenom: 'kenji',
+        nom: 'Jirac',
+      },
     },
     {
       id: '3',

--- a/fixtures/rendez-vous.ts
+++ b/fixtures/rendez-vous.ts
@@ -21,8 +21,8 @@ export const uneListeDeRdv = (overrides: Partial<Rdv[]> = []): Rdv[] =>
       duration: '25 min',
       modality: 'En agence',
       jeune: {
-        id: '1',
-        prenom: 'kenji',
+        id: '2',
+        prenom: 'Raja',
         nom: 'Jirac',
       },
     },

--- a/interfaces/jeune.ts
+++ b/interfaces/jeune.ts
@@ -1,3 +1,12 @@
+/**
+ * TODO: utiliser cette interface en classe mère pour Jeune lorsque la traduction sera faite
+ */
+export interface BaseJeune {
+  id: string
+  prenom: string
+  nom: string
+}
+
 export type Jeune = {
   id: string
   firstName: string

--- a/interfaces/json/action.ts
+++ b/interfaces/json/action.ts
@@ -1,11 +1,11 @@
 import { ActionStatus } from 'interfaces/action'
 
 export type JeuneActionsJson = {
-  jeuneId: string,
-  jeuneFirstName: string,
-  jeuneLastName: string,
-  todoActionsCount: number,
-  doneActionsCount: number,
+  jeuneId: string
+  jeuneFirstName: string
+  jeuneLastName: string
+  todoActionsCount: number
+  doneActionsCount: number
   inProgressActionsCount: number
 }
 

--- a/interfaces/json/rdv.ts
+++ b/interfaces/json/rdv.ts
@@ -1,12 +1,14 @@
+import { BaseJeune } from 'interfaces/jeune'
+
 export type RdvJson = {
   id: string
-  title: string
   subtitle: string
   comment: string
   date: string
   duration: string
   jeuneId: string
   modality: string
+  jeune: BaseJeune
 }
 
 export interface RdvFormData {

--- a/interfaces/rdv.ts
+++ b/interfaces/rdv.ts
@@ -1,18 +1,20 @@
+import { BaseJeune } from 'interfaces/jeune'
+
 export type Rdv = {
   id: string
-  title: string
   subtitle: string
   comment: string
   date: string
   duration: string
   modality: string
+  jeune: BaseJeune
 }
 
 export type RdvJeune = {
   id: string
-  title: string
   comment: string
   date: string
   duration: string
   modality: string
+  jeune: BaseJeune
 }

--- a/tests/components/ListeRdvJeune.test.tsx
+++ b/tests/components/ListeRdvJeune.test.tsx
@@ -20,7 +20,7 @@ describe('<ListeRdvJeune', () => {
 
     expect(screen.getByText('21/10/2021 (07:00 - 30 min)')).toBeInTheDocument()
     expect(screen.getAllByText('En agence')[0]).toBeInTheDocument()
-    expect(screen.getByText('Rendez-vous avec Rama')).toBeInTheDocument()
+    expect(screen.getByText('Rendez-vous avec Kenji')).toBeInTheDocument()
   })
 
   it('ne devrait pas afficher un tableau de rdvs quand rdvs est vide', () => {


### PR DESCRIPTION
fix: modal de deleteRDV utiliser jeune prenom nom au lieu de title.

[PR équivalente BE](https://github.com/SocialGouv/pass-emploi-api/pull/184)