### PR TITLE
fix: Correction message non par conseiller après envoi multi

### DIFF
--- a/components/layouts/ChatRoom.tsx
+++ b/components/layouts/ChatRoom.tsx
@@ -82,7 +82,6 @@ export default function ChatRoom() {
 
     setJeunesChats([...currentJeunesChat])
   }
-
   return (
     <article className={styles.chatRoom}>
       {isInConversation() && (
@@ -117,11 +116,12 @@ export default function ChatRoom() {
                         >
                           <span className='text-lg-semi text-bleu_nuit mb-2 w-full flex justify-between'>
                             {jeuneChat.firstName} {jeuneChat.lastName}
-                            {!jeuneChat.seenByConseiller && (
-                              <span className='text-violet text-xs border px-[7px] py-[5px] float-right rounded-x_small'>
-                                Nouveau message
-                              </span>
-                            )}
+                            {!jeuneChat.seenByConseiller &&
+                              jeuneChat.lastMessageContent && (
+                                <span className='text-violet text-xs border px-[7px] py-[5px] float-right rounded-x_small'>
+                                  Nouveau message
+                                </span>
+                              )}
                           </span>
                           <span className='text-sm text-bleu_gris mb-[8px]'>
                             {' '}

--- a/components/layouts/Conversation.tsx
+++ b/components/layouts/Conversation.tsx
@@ -42,12 +42,12 @@ export default function Conversation({ jeuneChat, onBack }: ConversationProps) {
 
   const sendNouveauMessage = async (event: any) => {
     event.preventDefault()
-    await messagesService.sendNouveauMessage(
+    messagesService.sendNouveauMessage(
       {
         id: session!.user.id,
         structure: session!.user.structure,
       },
-      [jeuneChat],
+      jeuneChat,
       newMessage,
       session!.accessToken
     )

--- a/fixtures/services.ts
+++ b/fixtures/services.ts
@@ -43,6 +43,7 @@ export function mockedMessagesService(
     signIn: jest.fn(),
     signOut: jest.fn(),
     sendNouveauMessage: jest.fn(),
+    sendNouveauMessageGroupe: jest.fn(),
   }
   return { ...defaults, ...overrides }
 }

--- a/pages/mes-jeunes/envoi-message-groupe.tsx
+++ b/pages/mes-jeunes/envoi-message-groupe.tsx
@@ -50,7 +50,7 @@ function EnvoiMessageGroupe({ jeunes, from }: EnvoiMessageGroupeProps) {
     if (!formIsValid()) return
     try {
       await messagesService.signIn(session!.firebaseToken)
-      await messagesService.sendNouveauMessage(
+      await messagesService.sendNouveauMessageGroupe(
         { id: session!.user.id, structure: session!.user.structure },
         selectedJeunes,
         message,

--- a/tests/components/Conversation.test.tsx
+++ b/tests/components/Conversation.test.tsx
@@ -135,7 +135,7 @@ describe('<Conversation />', () => {
             id: conseiller.id,
             structure: conseiller.structure,
           },
-          [jeuneChat],
+          jeuneChat,
           newMessage,
           accessToken
         )

--- a/tests/components/RechercheJeune.test.tsx
+++ b/tests/components/RechercheJeune.test.tsx
@@ -1,4 +1,4 @@
-import { desJeunes } from 'fixtures/jeune'
+import { desJeunesAvecActionsNonTerminees } from 'fixtures/jeune'
 import renderWithSession from '../renderWithSession'
 import MesJeunes from 'pages/mes-jeunes'
 import { UserStructure } from 'interfaces/conseiller'
@@ -14,7 +14,7 @@ describe('Recherche', () => {
 
   beforeEach(async () => {
     //GIVEN
-    const jeunes = desJeunes()
+    const jeunes = desJeunesAvecActionsNonTerminees()
 
     messagesService = mockedMessagesService({
       signIn: jest.fn(() => Promise.resolve()),

--- a/tests/pages/EnvoiMessageGroupe.page.test.tsx
+++ b/tests/pages/EnvoiMessageGroupe.page.test.tsx
@@ -35,7 +35,7 @@ describe('EnvoiMessageGroupe', () => {
     jeunesService = mockedJeunesService()
 
     messagesService = mockedMessagesService({
-      sendNouveauMessage: jest.fn(() => {
+      sendNouveauMessageGroupe: jest.fn(() => {
         return Promise.resolve()
       }),
     })
@@ -128,7 +128,7 @@ describe('EnvoiMessageGroupe', () => {
 
       // Then
       await waitFor(() => {
-        expect(messagesService.sendNouveauMessage).toHaveBeenCalledWith(
+        expect(messagesService.sendNouveauMessageGroupe).toHaveBeenCalledWith(
           { id: '1', structure: UserStructure.MILO },
           destinataires,
           newMessage,
@@ -154,7 +154,9 @@ describe('EnvoiMessageGroupe', () => {
       // Given
       const messageErreur =
         "Suite à un problème inconnu l'envoi du message a échoué. Vous pouvez réessayer."
-      ;(messagesService.sendNouveauMessage as Mock<any>).mockRejectedValue({
+      ;(
+        messagesService.sendNouveauMessageGroupe as Mock<any>
+      ).mockRejectedValue({
         message: 'whatever',
       })
 
@@ -165,7 +167,9 @@ describe('EnvoiMessageGroupe', () => {
 
       // Then
       await waitFor(() => {
-        expect(messagesService.sendNouveauMessage).toHaveBeenCalledTimes(1)
+        expect(messagesService.sendNouveauMessageGroupe).toHaveBeenCalledTimes(
+          1
+        )
       })
       expect(screen.getByText(messageErreur)).toBeInTheDocument()
     })

--- a/tests/services/messages.service.test.ts
+++ b/tests/services/messages.service.test.ts
@@ -208,6 +208,73 @@ describe('MessagesFirebaseAndApiService', () => {
     })
   })
 
+  describe('.sendNouveauMessage', () => {
+    let conseiller: { id: string; structure: UserStructure }
+    let jeuneChat: JeuneChat
+    let newMessage: string
+    const now = new Date()
+    beforeEach(async () => {
+      // Given
+      jest.setSystemTime(now)
+      jeuneChat = unJeuneChat()
+      newMessage = 'nouveauMessage'
+      // When
+      conseiller = { id: 'idConseiller', structure: UserStructure.POLE_EMPLOI }
+      await messagesService.sendNouveauMessage(
+        conseiller,
+        jeuneChat,
+        newMessage,
+        accessToken
+      )
+    })
+    it('adds a new message to firebase', async () => {
+      // Then
+      expect(firebaseClient.addMessage).toHaveBeenCalledWith(
+        jeuneChat.chatId,
+        {
+          encryptedText: `Encrypted: ${newMessage}`,
+          iv: `IV: ${newMessage}`,
+        },
+        now
+      )
+    })
+    it('updates chat in firebase', async () => {
+      // Then
+      expect(firebaseClient.updateChat).toHaveBeenCalledWith(jeuneChat.chatId, {
+        lastMessageContent: `Encrypted: ${newMessage}`,
+        lastMessageIv: `IV: ${newMessage}`,
+        lastMessageSentAt: now,
+        lastMessageSentBy: 'conseiller',
+        newConseillerMessageCount: jeuneChat.newConseillerMessageCount + 1,
+        seenByConseiller: true,
+        lastConseillerReading: now,
+      })
+    })
+    it('notifies of a new message', async () => {
+      // Then
+      expect(apiClient.post).toHaveBeenCalledWith(
+        `/conseillers/${conseiller.id}/jeunes/${jeuneChat.id}/notify-message`,
+        undefined,
+        accessToken
+      )
+    })
+    it('tracks new message', async () => {
+      // Then
+      expect(apiClient.post).toHaveBeenCalledWith(
+        '/evenements',
+        {
+          type: 'MESSAGE_ENVOYE',
+          emetteur: {
+            type: 'CONSEILLER',
+            structure: conseiller.structure,
+            id: conseiller.id,
+          },
+        },
+        accessToken
+      )
+    })
+  })
+
   describe('.sendNouveauMessageMultiple', () => {
     let destinataires: Jeune[]
     let idsJeunes: string[]
@@ -237,7 +304,7 @@ describe('MessagesFirebaseAndApiService', () => {
       chats = idsJeunes.map((idJeune) => unChat({ chatId: `chat-${idJeune}` }))
       ;(firebaseClient.getChatsDesJeunes as jest.Mock).mockResolvedValue(chats)
 
-      await messagesService.sendNouveauMessage(
+      await messagesService.sendNouveauMessageGroupe(
         { id: conseiller.id, structure: UserStructure.MILO },
         destinataires,
         newMessageGroupe,
@@ -277,8 +344,8 @@ describe('MessagesFirebaseAndApiService', () => {
           lastMessageSentAt: now,
           lastMessageSentBy: 'conseiller',
           newConseillerMessageCount: chat.newConseillerMessageCount + 1,
-          seenByConseiller: true,
-          lastConseillerReading: now,
+          seenByConseiller: false,
+          lastConseillerReading: new Date(0),
         })
       })
     })


### PR DESCRIPTION
fix: conseiller avec un message non lu d'un jeune + envoi message groupé doit rester comme non lu
fix: conversations vides sans pastille "message non lu"