### PR TITLE
Fix/a11y modal and 500 edition rdv

### DIFF
--- a/components/ExitPageConfirmationModal.tsx
+++ b/components/ExitPageConfirmationModal.tsx
@@ -1,4 +1,5 @@
 import Button, { ButtonStyle } from 'components/ui/Button'
+import { MouseEvent, useRef } from 'react'
 import { UrlObject } from 'url'
 import WarningIcon from '../assets/icons/warning.svg'
 import Modal from './Modal'
@@ -17,8 +18,12 @@ export default function ExitPageConfirmationModal({
   source = 'creation',
   destination,
 }: ExitPageConfirmationModalProps) {
+  const modalRef = useRef<{
+    closeModal: (e: KeyboardEvent | MouseEvent) => void
+  }>(null)
+
   return (
-    <Modal title='Quitter la page ?' onClose={onCancel}>
+    <Modal title='Quitter la page ?' onClose={onCancel} ref={modalRef}>
       <div className='px-20 text-center'>
         <WarningIcon focusable={false} aria-hidden={true} className='m-auto' />
         <p className='mt-6 text-base-medium'>{message}</p>
@@ -32,7 +37,7 @@ export default function ExitPageConfirmationModal({
         <Button
           type='button'
           style={ButtonStyle.SECONDARY}
-          onClick={onCancel}
+          onClick={(e) => modalRef.current!.closeModal(e)}
           className='mr-3'
         >
           Annuler

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -1,4 +1,12 @@
-import { MouseEvent, ReactNode, useEffect, useRef, useState } from 'react'
+import {
+  forwardRef,
+  MouseEvent,
+  ReactNode,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react'
 import { createPortal } from 'react-dom'
 import styles from 'styles/components/Modal.module.css'
 import BackIcon from '../assets/icons/back_modale.svg'
@@ -14,15 +22,21 @@ interface ModalProps {
   customWidth?: string
 }
 
-export default function Modal({
-  title,
-  onClose,
-  children: modalContent,
-  showTitle = true,
-  onBack,
-  customHeight,
-  customWidth,
-}: ModalProps) {
+const Modal = forwardRef((props: ModalProps, ref) => {
+  const {
+    children: modalContent,
+    customHeight,
+    customWidth,
+    onBack,
+    onClose,
+    showTitle = true,
+    title,
+  } = props
+
+  useImperativeHandle(ref, () => ({
+    closeModal: handleClose,
+  }))
+
   const [isBrowser, setIsBrowser] = useState(false)
   const modalRef = useRef<HTMLDivElement>(null)
   const previousFocusedElement = useRef<HTMLElement | null>(null)
@@ -153,4 +167,7 @@ export default function Modal({
   } else {
     return null
   }
-}
+})
+
+Modal.displayName = 'Modal'
+export default Modal

--- a/pages/mes-jeunes/edition-rdv.tsx
+++ b/pages/mes-jeunes/edition-rdv.tsx
@@ -113,7 +113,7 @@ function EditionRdv({
           idJeune={idJeune}
           rdv={rdv}
           redirectTo={redirectTo}
-          conseillerEmail={session!.user?.email}
+          conseillerEmail={session?.user.email ?? ''}
           onChanges={setHasChanges}
           soumettreRendezVous={soumettreRendezVous}
           leaveWithChanges={openLeavePageModal}


### PR DESCRIPTION
- [x] appelle `handleClose` de la modale quand un bouton injecté dans la modale a besoin de la fermer
- [x] corrige erreur 500 au refresh/accès direct à la modification de rdv (causé par `session === null`)