### PR TITLE
[FEAT] 644 - Ajouter le lien vers la fiche i-Milo dans le détail fiche jeune

### DIFF
--- a/components/jeune/DetailsJeune.tsx
+++ b/components/jeune/DetailsJeune.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import EmailIcon from '../../assets/icons/email.svg'
+import LaunchIcon from '../../assets/icons/launch.svg'
 
 import { Jeune } from 'interfaces/jeune'
 import { formatDayDate } from 'utils/date'
@@ -23,6 +24,24 @@ export const DetailsJeune = ({ jeune }: DetailsJeuneProps) => {
             <EmailIcon focusable='false' role='img' title='e-mail' />
           </dt>
           <dd>{jeune.email}</dd>
+        </dl>
+      )}
+
+      {jeune.urlDossierMilo && (
+        <dl className='mt-2 flex text-sm-semi items-center'>
+          <dd>
+            <a
+              className='underline text-primary hover:text-primary_darken'
+              href={jeune.urlDossierMilo}
+              target='_blank'
+              rel='noopener noreferrer'
+            >
+              Dossier jeune i-Milo
+            </a>
+          </dd>
+          <dt className='ml-2'>
+            <LaunchIcon focusable='false' role='img' title='ouvrir' />
+          </dt>
         </dl>
       )}
 

--- a/components/jeune/DetailsJeune.tsx
+++ b/components/jeune/DetailsJeune.tsx
@@ -35,13 +35,13 @@ export const DetailsJeune = ({
             </dd>
           </>
         )}
-        {jeune.urlDossierMilo && (
+        {jeune.urlDossier && (
           <>
             <dt className='sr-only'>Dossier externe</dt>
             <dd className='mt-2'>
               <a
                 className='underline text-primary hover:text-primary_darken flex items-center'
-                href={jeune.urlDossierMilo}
+                href={jeune.urlDossier}
                 target='_blank'
                 onClick={onDossierMiloClick}
                 rel='noopener noreferrer'

--- a/components/jeune/DetailsJeune.tsx
+++ b/components/jeune/DetailsJeune.tsx
@@ -17,38 +17,47 @@ export const DetailsJeune = ({
 }: DetailsJeuneProps) => {
   return (
     <>
-      <dl className='flex text-sm-semi mb-2'>
-        <dt className='mr-2'>Ajouté le :</dt>
-        <dd>{formatDayDate(new Date(jeune.creationDate))}</dd>
+      <dl className='text-sm-semi'>
+        <dt className='sr-only'>Ajouté le</dt>
+        <dd aria-label={formatDayDate(new Date(jeune.creationDate))}>
+          Ajouté le : {formatDayDate(new Date(jeune.creationDate))}
+        </dd>
+        {jeune.email && (
+          <>
+            <dt className='sr-only'>e-mail</dt>
+            <dd className='flex items-center mt-2'>
+              <EmailIcon
+                aria-hidden={true}
+                focusable='false'
+                className='mr-2'
+              />
+              {jeune.email}
+            </dd>
+          </>
+        )}
+        {jeune.urlDossierMilo && (
+          <>
+            <dt className='sr-only'>Dossier externe</dt>
+            <dd className='mt-2'>
+              <a
+                className='underline text-primary hover:text-primary_darken flex items-center'
+                href={jeune.urlDossierMilo}
+                target='_blank'
+                onClick={onDossierMiloClick}
+                rel='noopener noreferrer'
+              >
+                Dossier jeune i-Milo
+                <LaunchIcon
+                  focusable='false'
+                  role='img'
+                  title='ouvrir'
+                  className='ml-2'
+                />
+              </a>
+            </dd>
+          </>
+        )}
       </dl>
-
-      {jeune.email && (
-        <dl className='flex text-sm-semi'>
-          <dt className='mr-2'>
-            <EmailIcon focusable='false' role='img' title='e-mail' />
-          </dt>
-          <dd>{jeune.email}</dd>
-        </dl>
-      )}
-
-      {jeune.urlDossierMilo && (
-        <dl className='mt-2 flex text-sm-semi items-center'>
-          <dd>
-            <a
-              className='underline text-primary hover:text-primary_darken'
-              href={jeune.urlDossierMilo}
-              target='_blank'
-              onClick={onDossierMiloClick}
-              rel='noopener noreferrer'
-            >
-              Dossier jeune i-Milo
-            </a>
-          </dd>
-          <dt className='ml-2'>
-            <LaunchIcon focusable='false' role='img' title='ouvrir' />
-          </dt>
-        </dl>
-      )}
 
       {!jeune.isActivated && (
         <p className='mt-4 bg-warning_lighten py-4 px-7 rounded-medium max-w-md text-center'>

--- a/components/jeune/DetailsJeune.tsx
+++ b/components/jeune/DetailsJeune.tsx
@@ -8,9 +8,13 @@ import { formatDayDate } from 'utils/date'
 
 interface DetailsJeuneProps {
   jeune: Jeune
+  onDossierMiloClick: () => void
 }
 
-export const DetailsJeune = ({ jeune }: DetailsJeuneProps) => {
+export const DetailsJeune = ({
+  jeune,
+  onDossierMiloClick,
+}: DetailsJeuneProps) => {
   return (
     <>
       <dl className='flex text-sm-semi mb-2'>
@@ -34,6 +38,7 @@ export const DetailsJeune = ({ jeune }: DetailsJeuneProps) => {
               className='underline text-primary hover:text-primary_darken'
               href={jeune.urlDossierMilo}
               target='_blank'
+              onClick={onDossierMiloClick}
               rel='noopener noreferrer'
             >
               Dossier jeune i-Milo

--- a/interfaces/jeune.ts
+++ b/interfaces/jeune.ts
@@ -17,7 +17,7 @@ export interface Jeune {
   lastActivity: string
   email?: string
   isActivated?: boolean
-  urlDossierMilo?: string
+  urlDossier?: string
   conseillerPrecedent?: {
     nom: string
     prenom: string

--- a/interfaces/jeune.ts
+++ b/interfaces/jeune.ts
@@ -17,6 +17,7 @@ export interface Jeune {
   lastActivity: string
   email?: string
   isActivated?: boolean
+  urlDossierMilo?: string
   conseillerPrecedent?: {
     nom: string
     prenom: string
@@ -94,6 +95,7 @@ export function compareJeunesBySituation(jeune1: Jeune, jeune2: Jeune): number {
     `${jeune2.situationCourante}`
   )
 }
+
 export function compareJeunesBySituationDesc(
   jeune1: Jeune,
   jeune2: Jeune

--- a/interfaces/json/jeune.ts
+++ b/interfaces/json/jeune.ts
@@ -8,7 +8,7 @@ export interface JeuneJson {
   lastActivity: string
   email?: string
   isActivated?: boolean
-  urlDossierMilo?: string
+  urlDossier?: string
   conseillerPrecedent?: {
     nom: string
     prenom: string

--- a/interfaces/json/jeune.ts
+++ b/interfaces/json/jeune.ts
@@ -8,6 +8,7 @@ export interface JeuneJson {
   lastActivity: string
   email?: string
   isActivated?: boolean
+  urlDossierMilo?: string
   conseillerPrecedent?: {
     nom: string
     prenom: string

--- a/pages/mes-jeunes/[jeune_id]/index.tsx
+++ b/pages/mes-jeunes/[jeune_id]/index.tsx
@@ -125,6 +125,10 @@ function FicheJeune({
     }
   }
 
+  function trackDossierMiloClick() {
+    setTrackingLabel(pageTracking + ' - Dossier i-Milo')
+  }
+
   useMatomo(trackingLabel)
 
   useEffect(() => {
@@ -172,7 +176,7 @@ function FicheJeune({
           onAcknowledge={closeMessageGroupeEnvoiSuccess}
         />
       )}
-      <DetailsJeune jeune={jeune} />
+      <DetailsJeune jeune={jeune} onDossierMiloClick={trackDossierMiloClick} />
 
       <div className='mt-8'>
         <h2 className='text-base-medium mb-2'>Historique des conseillers</h2>

--- a/tests/components/DetailsJeune.test.tsx
+++ b/tests/components/DetailsJeune.test.tsx
@@ -10,7 +10,7 @@ describe('<DetailsJeune>', () => {
     // Given
     const jeune = unJeune({
       isActivated: true,
-      urlDossierMilo: 'https://dossier-milo.fr',
+      urlDossier: 'https://dossier-milo.fr',
     })
 
     // When
@@ -40,9 +40,9 @@ describe('<DetailsJeune>', () => {
     expect(screen.queryByTitle('e-mail')).toBeNull()
   })
 
-  it("n'affiche pas le lien vers le dossier MILO si le jeune n'en a pas", () => {
+  it("n'affiche pas le lien vers le dossier si le jeune n'en a pas", () => {
     // Given
-    const jeune = unJeune({ urlDossierMilo: undefined })
+    const jeune = unJeune({ urlDossier: undefined })
 
     // When
     render(<DetailsJeune jeune={jeune} onDossierMiloClick={() => {}} />)

--- a/tests/components/DetailsJeune.test.tsx
+++ b/tests/components/DetailsJeune.test.tsx
@@ -14,20 +14,18 @@ describe('<DetailsJeune>', () => {
     })
 
     // When
-    render(<DetailsJeune jeune={jeune} />)
+    render(<DetailsJeune jeune={jeune} onDossierMiloClick={() => {}} />)
 
     // Then
     expect(() =>
       screen.getByText('pas encore connecté', { exact: false })
     ).toThrow()
     expect(screen.getByText('kenji.jirac@email.fr')).toBeInTheDocument()
-    expect(screen.getByTitle('e-mail')).toBeInTheDocument()
-    expect(screen.getByText('Dossier jeune i-Milo')).toBeInTheDocument()
     expect(screen.getByText('Dossier jeune i-Milo')).toHaveAttribute(
       'href',
       'https://dossier-milo.fr'
     )
-    expect(screen.getByText('07/12/2021')).toBeInTheDocument()
+    expect(screen.getByLabelText('07/12/2021')).toBeInTheDocument()
   })
 
   it("n'affiche pas le mail si le jeune n'en a pas", () => {
@@ -36,7 +34,7 @@ describe('<DetailsJeune>', () => {
     delete jeune.email
 
     // When
-    render(<DetailsJeune jeune={jeune} />)
+    render(<DetailsJeune jeune={jeune} onDossierMiloClick={() => {}} />)
 
     // Then
     expect(screen.queryByTitle('e-mail')).toBeNull()
@@ -47,7 +45,7 @@ describe('<DetailsJeune>', () => {
     const jeune = unJeune({ urlDossierMilo: undefined })
 
     // When
-    render(<DetailsJeune jeune={jeune} />)
+    render(<DetailsJeune jeune={jeune} onDossierMiloClick={() => {}} />)
 
     // Then
     expect(screen.queryByText('Dossier jeune i-Milo')).toBeNull()
@@ -60,7 +58,7 @@ describe('<DetailsJeune>', () => {
       jeune = unJeune({ isActivated: false })
 
       // When
-      render(<DetailsJeune jeune={jeune} />)
+      render(<DetailsJeune jeune={jeune} onDossierMiloClick={() => {}} />)
     })
 
     it("affiche l'information", () => {

--- a/tests/components/DetailsJeune.test.tsx
+++ b/tests/components/DetailsJeune.test.tsx
@@ -8,7 +8,10 @@ import { Jeune } from 'interfaces/jeune'
 describe('<DetailsJeune>', () => {
   it("devrait afficher les informations de la fiche d'une jeune", () => {
     // Given
-    const jeune = unJeune({ isActivated: true })
+    const jeune = unJeune({
+      isActivated: true,
+      urlDossierMilo: 'https://dossier-milo.fr',
+    })
 
     // When
     render(<DetailsJeune jeune={jeune} />)
@@ -19,6 +22,11 @@ describe('<DetailsJeune>', () => {
     ).toThrow()
     expect(screen.getByText('kenji.jirac@email.fr')).toBeInTheDocument()
     expect(screen.getByTitle('e-mail')).toBeInTheDocument()
+    expect(screen.getByText('Dossier jeune i-Milo')).toBeInTheDocument()
+    expect(screen.getByText('Dossier jeune i-Milo')).toHaveAttribute(
+      'href',
+      'https://dossier-milo.fr'
+    )
     expect(screen.getByText('07/12/2021')).toBeInTheDocument()
   })
 
@@ -32,6 +40,17 @@ describe('<DetailsJeune>', () => {
 
     // Then
     expect(screen.queryByTitle('e-mail')).toBeNull()
+  })
+
+  it("n'affiche pas le lien vers le dossier MILO si le jeune n'en a pas", () => {
+    // Given
+    const jeune = unJeune({ urlDossierMilo: undefined })
+
+    // When
+    render(<DetailsJeune jeune={jeune} />)
+
+    // Then
+    expect(screen.queryByText('Dossier jeune i-Milo')).toBeNull()
   })
 
   describe("quand le jeune ne s'est jamais connecté", () => {

--- a/tests/services/jeunes.service.test.ts
+++ b/tests/services/jeunes.service.test.ts
@@ -92,7 +92,7 @@ describe('JeunesApiService', () => {
       // Given
       ;(apiClient.get as jest.Mock).mockResolvedValue(
         unJeuneJson({
-          urlDossierMilo: 'url-dossier-milo',
+          urlDossier: 'url-dossier',
         })
       )
 
@@ -109,7 +109,7 @@ describe('JeunesApiService', () => {
       )
       expect(actual).toEqual(
         unJeune({
-          urlDossierMilo: 'url-dossier-milo',
+          urlDossier: 'url-dossier',
         })
       )
     })

--- a/tests/services/jeunes.service.test.ts
+++ b/tests/services/jeunes.service.test.ts
@@ -90,7 +90,11 @@ describe('JeunesApiService', () => {
   describe('.getJeuneDetails', () => {
     it('renvoie les détails du jeune', async () => {
       // Given
-      ;(apiClient.get as jest.Mock).mockResolvedValue(unJeuneJson())
+      ;(apiClient.get as jest.Mock).mockResolvedValue(
+        unJeuneJson({
+          urlDossierMilo: 'url-dossier-milo',
+        })
+      )
 
       // When
       const actual = await jeunesService.getJeuneDetails(
@@ -103,7 +107,11 @@ describe('JeunesApiService', () => {
         '/jeunes/id-jeune',
         'accessToken'
       )
-      expect(actual).toEqual(unJeune())
+      expect(actual).toEqual(
+        unJeune({
+          urlDossierMilo: 'url-dossier-milo',
+        })
+      )
     })
 
     it("renvoie undefined si le jeune n'existe pas", async () => {

--- a/utils/analytics/useMatomo.tsx
+++ b/utils/analytics/useMatomo.tsx
@@ -1,5 +1,6 @@
-import { UserStructure } from 'interfaces/conseiller'
 import { useEffect } from 'react'
+
+import { UserStructure } from 'interfaces/conseiller'
 import { track } from 'utils/analytics/matomo'
 import useSession from 'utils/auth/useSession'
 


### PR DESCRIPTION
- [x] MAJ modèle JSON & métier + tests
- [x] MAJ UI  + tests
- [x] tracking

Pour tester tant que le back n'est pas là, vous pouvez checkout la branche et renseigner en dur un `urlDossierMilo` dans la méthode `jsonToJeune` du ficher `jeune.ts`.

J'ai un doute sur le fait d'utiliser une balise `<a>` plutôt qu'un `Link` React (ou Next ?). Et pour le reste, j'ai essayé de m'inspirer au plus du code existant, tell me :)
