### PR TITLE
fix: remove all permanent redirection

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -99,7 +99,7 @@ export const getServerSideProps: GetServerSideProps<HomePageProps> = async (
     return {
       redirect: {
         destination: `${redirectUrl}`,
-        permanent: true,
+        permanent: false,
       },
     }
   }

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -28,9 +28,7 @@ function Login({ ssoPassEmploiEstActif, isFromEmail }: LoginProps) {
           : '/'
         await signIn(
           'keycloak',
-          {
-            callbackUrl: callbackUrl,
-          },
+          { callbackUrl },
           { kc_idp_hint: provider ?? '' }
         )
       } catch (error) {
@@ -56,6 +54,7 @@ function Login({ ssoPassEmploiEstActif, isFromEmail }: LoginProps) {
   }
 
   useMatomo(isFromEmail ? 'Connexion - Origine email' : 'Connexion')
+
   return (
     <div className={`${styles.login} w-full h-screen relative`}>
       <div className='absolute top-2/4 left-2/4 -translate-x-2/4 -translate-y-2/4'>
@@ -104,7 +103,7 @@ export const getServerSideProps: GetServerSideProps<{}> = async (
 
   if (session) {
     const redirectUrl: string =
-      (context.query.redirectUrl as string) ?? `/${querySource || ''}`
+      (context.query.redirectUrl as string) ?? `/index${querySource || ''}`
 
     return {
       redirect: {

--- a/pages/mes-jeunes/[jeune_id]/suppression.tsx
+++ b/pages/mes-jeunes/[jeune_id]/suppression.tsx
@@ -144,7 +144,7 @@ export const getServerSideProps: GetServerSideProps<
 
   if (jeune.isActivated) {
     return {
-      redirect: { destination: `/mes-jeunes/${jeune.id}`, permanent: true },
+      redirect: { destination: `/mes-jeunes/${jeune.id}`, permanent: false },
     }
   }
   return {

--- a/pages/mes-jeunes/milo/[numero_dossier].tsx
+++ b/pages/mes-jeunes/milo/[numero_dossier].tsx
@@ -18,7 +18,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
   const { user, accessToken } = sessionOrRedirect.session
   if (user.structure !== UserStructure.MILO) {
-    return { redirect: { destination: '/mes-jeunes', permanent: true } }
+    return { redirect: { destination: '/mes-jeunes', permanent: false } }
   }
 
   const numeroDossier = context.query.numero_dossier as string
@@ -37,7 +37,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     pathname: `/mes-jeunes/milo/${numeroDossier}`,
     refererUrl: context.req.headers.referer,
   })
-  return { redirect: { destination, permanent: true } }
+  return { redirect: { destination, permanent: false } }
 }
 
 export default MiloFicheJeune

--- a/pages/mes-jeunes/milo/index.tsx
+++ b/pages/mes-jeunes/milo/index.tsx
@@ -8,7 +8,7 @@ export const getServerSideProps = () => {
   return {
     redirect: {
       destination: '/mes-jeunes',
-      permanent: true,
+      permanent: false,
     },
   }
 }

--- a/pages/mes-jeunes/pole-emploi/index.tsx
+++ b/pages/mes-jeunes/pole-emploi/index.tsx
@@ -8,7 +8,7 @@ export const getServerSideProps = () => {
   return {
     redirect: {
       destination: '/mes-jeunes',
-      permanent: true,
+      permanent: false,
     },
   }
 }

--- a/tests/pages/FicheJeuneMilo.page.test.tsx
+++ b/tests/pages/FicheJeuneMilo.page.test.tsx
@@ -47,7 +47,7 @@ describe('Fiche Jeune MiLo', () => {
 
           // Then
           expect(actual).toEqual({
-            redirect: { destination: '/mes-jeunes', permanent: true },
+            redirect: { destination: '/mes-jeunes', permanent: false },
           })
         })
       })
@@ -87,7 +87,7 @@ describe('Fiche Jeune MiLo', () => {
             expect(actual).toEqual({
               redirect: {
                 destination: '/mes-jeunes/id-jeune',
-                permanent: true,
+                permanent: false,
               },
             })
           })
@@ -114,7 +114,7 @@ describe('Fiche Jeune MiLo', () => {
               refererUrl: 'referer-url',
             })
             expect(actual).toEqual({
-              redirect: { destination: '/mes-jeunes', permanent: true },
+              redirect: { destination: '/mes-jeunes', permanent: false },
             })
           })
         })

--- a/tests/pages/Home.page.test.tsx
+++ b/tests/pages/Home.page.test.tsx
@@ -293,7 +293,7 @@ describe('Home', () => {
 
         //Then
         expect(actual).toEqual({
-          redirect: { destination: '/mes-jeunes', permanent: true },
+          redirect: { destination: '/mes-jeunes', permanent: false },
         })
       })
       it('redirige vers l’url renseignée', async () => {
@@ -304,7 +304,7 @@ describe('Home', () => {
 
         //Then
         expect(actual).toEqual({
-          redirect: { destination: '/mes-rendezvous', permanent: true },
+          redirect: { destination: '/mes-rendezvous', permanent: false },
         })
       })
     })

--- a/tests/pages/SuppressionJeune.page.test.tsx
+++ b/tests/pages/SuppressionJeune.page.test.tsx
@@ -78,7 +78,7 @@ describe('Suppression Jeune', () => {
           expect(actual).toEqual({
             redirect: {
               destination: `/mes-jeunes/${jeune.id}`,
-              permanent: true,
+              permanent: false,
             },
           })
         })

--- a/tests/utils/withMandatorySessionOrRedirect.test.ts
+++ b/tests/utils/withMandatorySessionOrRedirect.test.ts
@@ -64,7 +64,7 @@ describe('withMandatorySessionOrRedirect', () => {
       expect(actual).toEqual({
         redirect: {
           destination: '/api/auth/federated-logout',
-          permanent: true,
+          permanent: false,
         },
         validSession: false,
       })

--- a/utils/auth/withMandatorySessionOrRedirect.ts
+++ b/utils/auth/withMandatorySessionOrRedirect.ts
@@ -30,7 +30,7 @@ export async function withMandatorySessionOrRedirect({
     return {
       redirect: {
         destination: '/api/auth/federated-logout',
-        permanent: true,
+        permanent: false,
       },
       validSession: false,
     }


### PR DESCRIPTION
Permanent redirection triggers browser optimisation which can cause problems if we want to break the redirection