### PR TITLE
fix(US-830): Corrige couleurs tags actions et margin tableau

### DIFF
--- a/components/action/ActionRow.tsx
+++ b/components/action/ActionRow.tsx
@@ -28,7 +28,7 @@ export default function ActionRow({ action, jeuneId }: ActionRowProps) {
           role='cell'
           className={`table-cell relative p-4 group-hover:rounded-l-[6px]`}
         >
-          <span className='flex items-center border-r border-grey_500 group-hover:border-blanc'>
+          <span className='flex items-center'>
             <span className='text-base-medium text-ellipsis overflow-hidden max-w-[400px] whitespace-nowrap'>
               {action.content}
             </span>
@@ -44,12 +44,12 @@ export default function ActionRow({ action, jeuneId }: ActionRowProps) {
           </span>
         </div>
         <div role='cell' className='table-cell relative py-4 pr-4 w-[120px]'>
-          <span className='flex items-center border-r border-grey_500 group-hover:border-blanc'>
+          <span className='flex items-center'>
             <span>{formatDayDate(new Date(action.creationDate))}</span>
           </span>
         </div>
         <div role='cell' className='table-cell relative py-4 pr-4 w-[120px]'>
-          <span className='flex flex-row items-center border-r border-grey_500 group-hover:border-blanc'>
+          <span className='flex flex-row items-center'>
             <span
               className={
                 actionEstEnRetard

--- a/components/action/TableauActionsJeune.tsx
+++ b/components/action/TableauActionsJeune.tsx
@@ -163,7 +163,7 @@ export default function TableauActionsJeune({
                 Statut
                 <IconComponent
                   name={IconName.ChevronDown}
-                  className={`h-4 w-4 fill-primary ${
+                  className={`h-4 w-4 ml-2 fill-primary ${
                     afficherStatut ? 'rotate-180' : ''
                   }`}
                 />

--- a/components/action/propsStatutsActions.ts
+++ b/components/action/propsStatutsActions.ts
@@ -17,21 +17,21 @@ const propsStatutsActions: {
   },
   Annulee: {
     label: 'Annulée',
-    color: 'accent_3',
-    altColor: 'accent_3_lighten',
-    iconName: IconName.Check,
-  },
-  Commencee: {
-    label: 'Commencée',
     color: 'accent_2',
     altColor: 'accent_2_lighten',
     iconName: IconName.Check,
   },
+  Commencee: {
+    label: 'Commencée',
+    color: 'accent_3',
+    altColor: 'accent_3_lighten',
+    iconName: IconName.Check,
+  },
   Terminee: {
     label: 'Terminée',
-    color: 'warning',
-    altColor: 'warning_lighten',
-    iconName: IconName.Cancel,
+    color: 'accent_2',
+    altColor: 'accent_2_lighten',
+    iconName: IconName.Check,
   },
 }
 

--- a/components/ui/SortIcon.tsx
+++ b/components/ui/SortIcon.tsx
@@ -12,7 +12,7 @@ export default function SortIcon({
       name={isSorted ? IconName.ArrowDown : IconName.ArrowDouble}
       focusable='false'
       aria-hidden='true'
-      className={`w-6 h-6 ${isDesc ? 'rotate-180' : ''}`}
+      className={`w-6 h-6 ml-2 ${isDesc ? 'rotate-180' : ''}`}
     />
   )
 }


### PR DESCRIPTION
- fix couleurs correctement associées aux statuts
- fix tableau, on se sentait un peu à l'étroit dans les lignes du tableau des actions et le header (:-D) , j'en ai profité pour mettre à jour iso lama system