### PR TITLE
feat(1023) : Afficher le détail indicateurs pour le conseiller MiLo

### DIFF
--- a/components/FilAriane.tsx
+++ b/components/FilAriane.tsx
@@ -19,6 +19,7 @@ export default function FilAriane({
     '/mes-jeunes/[jeune_id]': 'Fiche jeune',
     '/mes-jeunes/[jeune_id]/favoris': 'Favoris',
     '/mes-jeunes/[jeune_id]/historique': 'Historique',
+    '/mes-jeunes/[jeune_id]/indicateurs': 'Indicateurs',
     '/mes-jeunes/milo/creation-jeune': 'Création',
     '/mes-jeunes/pole-emploi/creation-jeune': 'Création',
     '/mes-jeunes/[jeune_id]/actions/[action_id]': 'Détail action',

--- a/components/jeune/IndicateursJeune.tsx
+++ b/components/jeune/IndicateursJeune.tsx
@@ -27,7 +27,9 @@ export function IndicateursJeune({
         {finDeLaSemaine.toLocaleString()}
       </p>
       <div
-        className={`flex gap-6 ${!indicateursSemaine ? 'animate-pulse' : ''}`}
+        className={`flex flex-wrap gap-6 ${
+          !indicateursSemaine ? 'animate-pulse' : ''
+        }`}
       >
         <div className='text-primary_darken text-base-bold'>
           <h3 className='mb-2'>Les actions</h3>

--- a/components/jeune/IndicateursJeune.tsx
+++ b/components/jeune/IndicateursJeune.tsx
@@ -1,17 +1,20 @@
 import { DateTime } from 'luxon'
+import Link from 'next/link'
 import React from 'react'
 
-import { IconName } from 'components/ui/IconComponent'
+import IconComponent, { IconName } from 'components/ui/IconComponent'
 import TileIndicateur from 'components/ui/TileIndicateur'
 import { IndicateursSemaine } from 'interfaces/jeune'
 
 type IndicateursJeuneProps = {
+  idJeune: string
   debutDeLaSemaine: DateTime
   finDeLaSemaine: DateTime
   indicateursSemaine: IndicateursSemaine | undefined
 }
 
 export function IndicateursJeune({
+  idJeune,
   debutDeLaSemaine,
   finDeLaSemaine,
   indicateursSemaine,
@@ -68,8 +71,24 @@ export function IndicateursJeune({
             />
           </div>
         </div>
-        <div></div>
       </div>
+      <LienVersIndicateurs idJeune={idJeune} />
     </div>
+  )
+}
+
+function LienVersIndicateurs(props: { idJeune: string }) {
+  return (
+    <Link href={`/mes-jeunes/${props.idJeune}/indicateurs`}>
+      <a className='flex items-center text-content_color underline hover:text-primary hover:fill-primary mt-4'>
+        Voir plus d’indicateurs
+        <IconComponent
+          name={IconName.ChevronRight}
+          className='w-4 h-5 fill-[inherit]'
+          aria-hidden={true}
+          focusable={false}
+        />
+      </a>
+    </Link>
   )
 }

--- a/components/jeune/ResumeIndicateursJeune.tsx
+++ b/components/jeune/ResumeIndicateursJeune.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 import IconComponent, { IconName } from 'components/ui/IconComponent'
 import TileIndicateur from 'components/ui/TileIndicateur'
 import { IndicateursSemaine } from 'interfaces/jeune'
+import { toFrenchString } from 'utils/date'
 
 type ResumeIndicateursJeuneProps = {
   idJeune: string
@@ -23,8 +24,8 @@ export function ResumeIndicateursJeune({
     <div className='border border-solid rounded-medium w-full p-4 border-grey_100'>
       <h2 className='text-m-bold'>Les indicateurs de la semaine</h2>
       <p className='mb-4'>
-        du {debutDeLaSemaine.toLocaleString()} au{' '}
-        {finDeLaSemaine.toLocaleString()}
+        du {toFrenchString(debutDeLaSemaine)} au{' '}
+        {toFrenchString(finDeLaSemaine)}
       </p>
       <div
         className={`flex flex-wrap gap-6 ${

--- a/components/jeune/ResumeIndicateursJeune.tsx
+++ b/components/jeune/ResumeIndicateursJeune.tsx
@@ -6,19 +6,19 @@ import IconComponent, { IconName } from 'components/ui/IconComponent'
 import TileIndicateur from 'components/ui/TileIndicateur'
 import { IndicateursSemaine } from 'interfaces/jeune'
 
-type IndicateursJeuneProps = {
+type ResumeIndicateursJeuneProps = {
   idJeune: string
   debutDeLaSemaine: DateTime
   finDeLaSemaine: DateTime
   indicateursSemaine: IndicateursSemaine | undefined
 }
 
-export function IndicateursJeune({
+export function ResumeIndicateursJeune({
   idJeune,
   debutDeLaSemaine,
   finDeLaSemaine,
   indicateursSemaine,
-}: IndicateursJeuneProps) {
+}: ResumeIndicateursJeuneProps) {
   return (
     <div className='border border-solid rounded-medium w-full p-4 border-grey_100'>
       <h2 className='text-m-bold'>Les indicateurs de la semaine</h2>

--- a/components/rdv/EditionRdvForm.tsx
+++ b/components/rdv/EditionRdvForm.tsx
@@ -20,7 +20,12 @@ import { BaseJeune } from 'interfaces/jeune'
 import { RdvFormData } from 'interfaces/json/rdv'
 import { Rdv, TYPE_RENDEZ_VOUS, TypeRendezVous } from 'interfaces/rdv'
 import { modalites } from 'referentiel/rdv'
-import { DATE_DASH_SEPARATOR, TIME_24_SIMPLE, toFrenchFormat } from 'utils/date'
+import {
+  DATE_DASH_SEPARATOR,
+  TIME_24_SIMPLE,
+  toFrenchFormat,
+  toFrenchString,
+} from 'utils/date'
 
 interface EditionRdvFormProps {
   jeunes: BaseJeune[]
@@ -71,8 +76,9 @@ export function EditionRdvForm({
   const localDate = dateRdv ? toFrenchFormat(dateRdv, DATE_DASH_SEPARATOR) : ''
   const [date, setDate] = useState<RequiredValue>({ value: localDate })
   const regexHoraire = /^([0-1]\d|2[0-3]):[0-5]\d$/
-  const localTime =
-    dateRdv?.toLocaleString(DateTime.TIME_24_SIMPLE, { locale: 'fr-FR' }) ?? ''
+  const localTime = dateRdv
+    ? toFrenchString(dateRdv, DateTime.TIME_24_SIMPLE)
+    : ''
   const [horaire, setHoraire] = useState<RequiredValue>({ value: localTime })
   const regexDuree = /^\d{2}:\d{2}$/
   const dureeRdv = dureeFromMinutes(rdv?.duration)

--- a/components/ui/TileIndicateur.tsx
+++ b/components/ui/TileIndicateur.tsx
@@ -15,7 +15,7 @@ export default function TileIndicateur({
 }) {
   return (
     <li
-      className={`flex flex-col p-3 rounded-medium ${
+      className={`flex flex-col shrink-0 p-3 rounded-medium ${
         parseInt(valeur, 10) > 0
           ? `bg-${bgColor} text-${textColor}`
           : 'bg-grey_100 text-grey_800'

--- a/fixtures/jeune.ts
+++ b/fixtures/jeune.ts
@@ -299,6 +299,14 @@ export const desIndicateursSemaineJson = (
     rendezVous: {
       planifies: 3,
     },
+    offres: {
+      consultees: 10,
+      partagees: 4,
+    },
+    favoris: {
+      offresSauvegardees: 6,
+      recherchesSauvegardees: 7,
+    },
   }
   return { ...defaults, ...overrides }
 }
@@ -313,6 +321,14 @@ export const desIndicateursSemaine = (
       terminees: 1,
     },
     rendezVous: 3,
+    offres: {
+      consultees: 10,
+      partagees: 4,
+    },
+    favoris: {
+      offresSauvegardees: 6,
+      recherchesSauvegardees: 7,
+    },
   }
   return { ...defaults, ...overrides }
 }

--- a/fixtures/jeune.ts
+++ b/fixtures/jeune.ts
@@ -295,6 +295,7 @@ export const desIndicateursSemaineJson = (
       creees: 0,
       enRetard: 2,
       terminees: 1,
+      aEcheance: 3,
     },
     rendezVous: {
       planifies: 3,
@@ -319,6 +320,7 @@ export const desIndicateursSemaine = (
       creees: 0,
       enRetard: 2,
       terminees: 1,
+      aEcheance: 3,
     },
     rendezVous: 3,
     offres: {

--- a/interfaces/jeune.ts
+++ b/interfaces/jeune.ts
@@ -118,6 +118,7 @@ export type IndicateursSemaine = {
     creees: number
     enRetard: number
     terminees: number
+    aEcheance: number
   }
   rendezVous: number
   offres: {

--- a/interfaces/jeune.ts
+++ b/interfaces/jeune.ts
@@ -41,6 +41,7 @@ export interface JeuneFromListe extends BaseJeune {
   }
   situationCourante: CategorieSituation
 }
+
 export interface DetailJeune extends BaseJeune {
   creationDate: string
   isActivated: boolean
@@ -119,6 +120,14 @@ export type IndicateursSemaine = {
     terminees: number
   }
   rendezVous: number
+  offres: {
+    consultees: number
+    partagees: number
+  }
+  favoris: {
+    offresSauvegardees: number
+    recherchesSauvegardees: number
+  }
 }
 
 export function compareJeunesByNom(

--- a/interfaces/json/jeune.ts
+++ b/interfaces/json/jeune.ts
@@ -69,6 +69,14 @@ export type IndicateursSemaineJson = {
   rendezVous: {
     planifies: number
   }
+  offres: {
+    consultees: number
+    partagees: number
+  }
+  favoris: {
+    offresSauvegardees: number
+    recherchesSauvegardees: number
+  }
 }
 
 function toEtatSituation(etat: string): EtatSituation | undefined {
@@ -185,6 +193,14 @@ export function jsonToIndicateursSemaine(
       terminees: indicateursJson.actions.terminees,
     },
     rendezVous: indicateursJson.rendezVous.planifies,
+    offres: {
+      partagees: indicateursJson.offres.partagees,
+      consultees: indicateursJson.offres.consultees,
+    },
+    favoris: {
+      offresSauvegardees: indicateursJson.favoris.offresSauvegardees,
+      recherchesSauvegardees: indicateursJson.favoris.recherchesSauvegardees,
+    },
   }
 }
 

--- a/interfaces/json/jeune.ts
+++ b/interfaces/json/jeune.ts
@@ -65,6 +65,7 @@ export type IndicateursSemaineJson = {
     creees: number
     enRetard: number
     terminees: number
+    aEcheance: number
   }
   rendezVous: {
     planifies: number
@@ -191,6 +192,7 @@ export function jsonToIndicateursSemaine(
       creees: indicateursJson.actions.creees,
       enRetard: indicateursJson.actions.enRetard,
       terminees: indicateursJson.actions.terminees,
+      aEcheance: indicateursJson.actions.aEcheance,
     },
     rendezVous: indicateursJson.rendezVous.planifies,
     offres: {

--- a/pages/mes-jeunes/[jeune_id].tsx
+++ b/pages/mes-jeunes/[jeune_id].tsx
@@ -2,14 +2,14 @@ import { withTransaction } from '@elastic/apm-rum-react'
 import { DateTime } from 'luxon'
 import { GetServerSideProps } from 'next'
 import { useRouter } from 'next/router'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 
 import { OngletActions } from 'components/action/OngletActions'
 import { BlocFavoris } from 'components/jeune/BlocFavoris'
 import DeleteJeuneActifModal from 'components/jeune/DeleteJeuneActifModal'
 import DeleteJeuneInactifModal from 'components/jeune/DeleteJeuneInactifModal'
 import { DetailsJeune } from 'components/jeune/DetailsJeune'
-import { IndicateursJeune } from 'components/jeune/IndicateursJeune'
+import { ResumeIndicateursJeune } from 'components/jeune/ResumeIndicateursJeune'
 import { OngletRdvs } from 'components/rdv/OngletRdvs'
 import ButtonLink from 'components/ui/Button/ButtonLink'
 import IconComponent, { IconName } from 'components/ui/IconComponent'
@@ -112,9 +112,9 @@ function FicheJeune({
     setShowSuppressionCompteBeneficiaireError,
   ] = useState<boolean>(false)
 
-  const aujourdHui = DateTime.now()
-  const debutDeLaSemaine = aujourdHui.startOf('week')
-  const finDeLaSemaine = aujourdHui.endOf('week')
+  const aujourdHui = useMemo(() => DateTime.now(), [])
+  const debutSemaine = useMemo(() => aujourdHui.startOf('week'), [aujourdHui])
+  const finSemaine = useMemo(() => aujourdHui.endOf('week'), [aujourdHui])
 
   const pageTracking: string = jeune.isActivated
     ? 'Détail jeune'
@@ -227,21 +227,17 @@ function FicheJeune({
     setIdCurrentJeune(jeune.id)
   }, [jeune, setIdCurrentJeune])
 
+  // On récupère les indicateurs ici parce qu'on a besoin de la timezone du navigateur
   useEffect(() => {
     if (conseiller && !isPoleEmploi && !indicateursSemaine) {
       jeunesService
-        .getIndicateursJeune(
-          conseiller.id,
-          jeune.id,
-          debutDeLaSemaine,
-          finDeLaSemaine
-        )
+        .getIndicateursJeune(conseiller.id, jeune.id, debutSemaine, finSemaine)
         .then(setIndicateursSemaine)
     }
   }, [
     conseiller,
-    debutDeLaSemaine,
-    finDeLaSemaine,
+    debutSemaine,
+    finSemaine,
     indicateursSemaine,
     jeune.id,
     jeunesService,
@@ -309,10 +305,10 @@ function FicheJeune({
       </div>
 
       {!isPoleEmploi && (
-        <IndicateursJeune
+        <ResumeIndicateursJeune
           idJeune={jeune.id}
-          debutDeLaSemaine={debutDeLaSemaine}
-          finDeLaSemaine={finDeLaSemaine}
+          debutDeLaSemaine={debutSemaine}
+          finDeLaSemaine={finSemaine}
           indicateursSemaine={indicateursSemaine}
         />
       )}

--- a/pages/mes-jeunes/[jeune_id].tsx
+++ b/pages/mes-jeunes/[jeune_id].tsx
@@ -310,6 +310,7 @@ function FicheJeune({
 
       {!isPoleEmploi && (
         <IndicateursJeune
+          idJeune={jeune.id}
           debutDeLaSemaine={debutDeLaSemaine}
           finDeLaSemaine={finDeLaSemaine}
           indicateursSemaine={indicateursSemaine}

--- a/pages/mes-jeunes/[jeune_id]/indicateurs.tsx
+++ b/pages/mes-jeunes/[jeune_id]/indicateurs.tsx
@@ -12,6 +12,7 @@ import { JeunesService } from 'services/jeunes.service'
 import useMatomo from 'utils/analytics/useMatomo'
 import { withMandatorySessionOrRedirect } from 'utils/auth/withMandatorySessionOrRedirect'
 import { useConseiller } from 'utils/conseiller/conseillerContext'
+import { toFrenchString } from 'utils/date'
 import { useDependance } from 'utils/injectionDependances'
 
 type IndicateursProps = PageProps & {
@@ -51,8 +52,8 @@ function Indicateurs({ idJeune }: IndicateursProps) {
   return (
     <div>
       <h2 className='text-m-bold text-content_color mb-6'>
-        Semaine du {debutSemaine.toLocaleString()} au{' '}
-        {finSemaine.toLocaleString()}
+        Semaine du {toFrenchString(debutSemaine)} au{' '}
+        {toFrenchString(finSemaine)}
       </h2>
 
       <IndicateursActions actions={indicateursSemaine?.actions} />

--- a/pages/mes-jeunes/[jeune_id]/indicateurs.tsx
+++ b/pages/mes-jeunes/[jeune_id]/indicateurs.tsx
@@ -9,6 +9,7 @@ import { StructureConseiller } from 'interfaces/conseiller'
 import { IndicateursSemaine } from 'interfaces/jeune'
 import { PageProps } from 'interfaces/pageProps'
 import { JeunesService } from 'services/jeunes.service'
+import useMatomo from 'utils/analytics/useMatomo'
 import { withMandatorySessionOrRedirect } from 'utils/auth/withMandatorySessionOrRedirect'
 import { useDependance } from 'utils/injectionDependances'
 
@@ -28,7 +29,7 @@ function Indicateurs({ idJeune, idConseiller }: IndicateursProps) {
   const debutDeLaSemaine = aujourdHui.startOf('week')
   const finDeLaSemaine = aujourdHui.endOf('week')
 
-  // TODO-GAD tracking
+  useMatomo('Détail jeune – Indicateurs')
 
   useEffect(() => {
     if (!indicateursSemaine) {

--- a/pages/mes-jeunes/[jeune_id]/indicateurs.tsx
+++ b/pages/mes-jeunes/[jeune_id]/indicateurs.tsx
@@ -58,106 +58,119 @@ function Indicateurs({ idJeune, idConseiller }: IndicateursProps) {
         {finDeLaSemaine.toLocaleString()}
       </h2>
 
-      <div className='border border-solid rounded-medium w-full p-4 border-grey_100'>
-        <h3 className='text-m-bold text-content_color mb-4'>Les actions</h3>
-        <ul className='flex gap-2'>
-          <TileIndicateur
-            valeur={indicateursSemaine?.actions.creees.toString() ?? '-'}
-            label={
-              indicateursSemaine?.actions.creees !== 1 ? 'Créées' : 'Créée'
-            }
-            bgColor='primary_lighten'
-            textColor='primary_darken'
-          />
-          <TileIndicateur
-            valeur={indicateursSemaine?.actions.enRetard.toString() ?? '-'}
-            label='En retard'
-            bgColor='alert_lighten'
-            textColor='content_color'
-            iconName={IconName.WarningRounded}
-          />
-          <TileIndicateur
-            valeur={indicateursSemaine?.actions.terminees.toString() ?? '-'}
-            label={
-              indicateursSemaine?.actions.terminees !== 1
-                ? 'Terminées'
-                : 'Terminée'
-            }
-            bgColor='accent_2_lighten'
-            textColor='accent_2'
-            iconName={IconName.RoundedCheck}
-          />
-          <TileIndicateur
-            valeur={indicateursSemaine?.actions.aEcheance.toString() ?? '-'}
-            label='Échéance cette semaine'
-            bgColor='primary_lighten'
-            textColor='primary_darken'
-          />
-        </ul>
-      </div>
+      <IndicateursActions actions={indicateursSemaine?.actions} />
 
-      <div className='border border-solid rounded-medium w-full mt-6 p-4 border-grey_100'>
-        <h3 className='text-m-bold text-content_color mb-4'>Les rendez-vous</h3>
-        <ul className='flex'>
-          <TileIndicateur
-            valeur={indicateursSemaine?.rendezVous.toString() ?? '-'}
-            label='Cette semaine'
-            bgColor='primary_lighten'
-            textColor='primary_darken'
-          />
-        </ul>
-      </div>
+      <IndicateursRendezvous rendezVous={indicateursSemaine?.rendezVous} />
 
-      <div className='border border-solid rounded-medium w-full mt-6 p-4 border-grey_100'>
-        <h3 className='text-m-bold text-content_color mb-4'>Les offres</h3>
-        <ul className='flex gap-2'>
-          <TileIndicateur
-            valeur={indicateursSemaine?.offres.consultees.toString() ?? '-'}
-            label={
-              indicateursSemaine?.offres.consultees !== 1
-                ? 'Offres consultées'
-                : 'Offre consultée'
-            }
-            bgColor='primary_lighten'
-            textColor='primary_darken'
-          />
-          <TileIndicateur
-            valeur={
-              indicateursSemaine?.favoris.offresSauvegardees.toString() ?? '-'
-            }
-            label={
-              indicateursSemaine?.favoris.offresSauvegardees !== 1
-                ? 'Favoris ajoutés'
-                : 'Favori ajouté'
-            }
-            bgColor='primary_lighten'
-            textColor='primary_darken'
-          />
-          <TileIndicateur
-            valeur={indicateursSemaine?.offres.partagees.toString() ?? '-'}
-            label={
-              indicateursSemaine?.offres.partagees !== 1
-                ? 'Offres partagées'
-                : 'Offre partagée'
-            }
-            bgColor='primary_lighten'
-            textColor='primary_darken'
-          />
-          <TileIndicateur
-            valeur={
-              indicateursSemaine?.favoris.recherchesSauvegardees.toString() ??
-              '-'
-            }
-            label={
-              indicateursSemaine?.favoris.recherchesSauvegardees !== 1
-                ? 'Recherches sauvegardées'
-                : 'Recherche sauvegardée'
-            }
-            bgColor='primary_lighten'
-            textColor='primary_darken'
-          />
-        </ul>
-      </div>
+      <IndicateursOffres
+        offres={indicateursSemaine?.offres}
+        favoris={indicateursSemaine?.favoris}
+      />
+    </div>
+  )
+}
+
+function IndicateursActions({
+  actions,
+}: Pick<Partial<IndicateursSemaine>, 'actions'>) {
+  return (
+    <div className='border border-solid rounded-medium w-full p-4 border-grey_100'>
+      <h3 className='text-m-bold text-content_color mb-4'>Les actions</h3>
+      <ul className='flex flex-wrap gap-2'>
+        <TileIndicateur
+          valeur={actions?.creees.toString() ?? '-'}
+          label={actions?.creees !== 1 ? 'Créées' : 'Créée'}
+          bgColor='primary_lighten'
+          textColor='primary_darken'
+        />
+        <TileIndicateur
+          valeur={actions?.enRetard.toString() ?? '-'}
+          label='En retard'
+          bgColor='alert_lighten'
+          textColor='content_color'
+          iconName={IconName.WarningRounded}
+        />
+        <TileIndicateur
+          valeur={actions?.terminees.toString() ?? '-'}
+          label={actions?.terminees !== 1 ? 'Terminées' : 'Terminée'}
+          bgColor='accent_2_lighten'
+          textColor='accent_2'
+          iconName={IconName.RoundedCheck}
+        />
+        <TileIndicateur
+          valeur={actions?.aEcheance.toString() ?? '-'}
+          label='Échéance cette semaine'
+          bgColor='primary_lighten'
+          textColor='primary_darken'
+        />
+      </ul>
+    </div>
+  )
+}
+
+function IndicateursRendezvous({
+  rendezVous,
+}: Partial<Pick<IndicateursSemaine, 'rendezVous'>>) {
+  return (
+    <div className='border border-solid rounded-medium w-full mt-6 p-4 border-grey_100'>
+      <h3 className='text-m-bold text-content_color mb-4'>Les rendez-vous</h3>
+      <ul className='flex'>
+        <TileIndicateur
+          valeur={rendezVous?.toString() ?? '-'}
+          label='Cette semaine'
+          bgColor='primary_lighten'
+          textColor='primary_darken'
+        />
+      </ul>
+    </div>
+  )
+}
+
+function IndicateursOffres({
+  offres,
+  favoris,
+}: Partial<Pick<IndicateursSemaine, 'offres' | 'favoris'>>) {
+  return (
+    <div className='border border-solid rounded-medium w-full mt-6 p-4 border-grey_100'>
+      <h3 className='text-m-bold text-content_color mb-4'>Les offres</h3>
+      <ul className='flex flex-wrap gap-2'>
+        <TileIndicateur
+          valeur={offres?.consultees.toString() ?? '-'}
+          label={
+            offres?.consultees !== 1 ? 'Offres consultées' : 'Offre consultée'
+          }
+          bgColor='primary_lighten'
+          textColor='primary_darken'
+        />
+        <TileIndicateur
+          valeur={favoris?.offresSauvegardees.toString() ?? '-'}
+          label={
+            favoris?.offresSauvegardees !== 1
+              ? 'Favoris ajoutés'
+              : 'Favori ajouté'
+          }
+          bgColor='primary_lighten'
+          textColor='primary_darken'
+        />
+        <TileIndicateur
+          valeur={offres?.partagees.toString() ?? '-'}
+          label={
+            offres?.partagees !== 1 ? 'Offres partagées' : 'Offre partagée'
+          }
+          bgColor='primary_lighten'
+          textColor='primary_darken'
+        />
+        <TileIndicateur
+          valeur={favoris?.recherchesSauvegardees.toString() ?? '-'}
+          label={
+            favoris?.recherchesSauvegardees !== 1
+              ? 'Recherches sauvegardées'
+              : 'Recherche sauvegardée'
+          }
+          bgColor='primary_lighten'
+          textColor='primary_darken'
+        />
+      </ul>
     </div>
   )
 }

--- a/pages/mes-jeunes/[jeune_id]/indicateurs.tsx
+++ b/pages/mes-jeunes/[jeune_id]/indicateurs.tsx
@@ -53,7 +53,7 @@ function Indicateurs({ idJeune, idConseiller }: IndicateursProps) {
 
   return (
     <div>
-      <h2 className='text-m-bold text-content_color mb-6 mt-2'>
+      <h2 className='text-m-bold text-content_color mb-6'>
         Semaine du {debutDeLaSemaine.toLocaleString()} au{' '}
         {finDeLaSemaine.toLocaleString()}
       </h2>

--- a/pages/mes-jeunes/[jeune_id]/indicateurs.tsx
+++ b/pages/mes-jeunes/[jeune_id]/indicateurs.tsx
@@ -3,7 +3,8 @@ import { DateTime } from 'luxon'
 import { GetServerSideProps } from 'next'
 import React, { useEffect, useState } from 'react'
 
-import { IndicateursJeune } from 'components/jeune/IndicateursJeune'
+import { IconName } from 'components/ui/IconComponent'
+import TileIndicateur from 'components/ui/TileIndicateur'
 import { StructureConseiller } from 'interfaces/conseiller'
 import { IndicateursSemaine } from 'interfaces/jeune'
 import { PageProps } from 'interfaces/pageProps'
@@ -50,11 +51,113 @@ function Indicateurs({ idJeune, idConseiller }: IndicateursProps) {
   ])
 
   return (
-    <IndicateursJeune
-      debutDeLaSemaine={debutDeLaSemaine}
-      finDeLaSemaine={finDeLaSemaine}
-      indicateursSemaine={indicateursSemaine}
-    />
+    <div>
+      <h2 className='text-m-bold text-content_color mb-6 mt-2'>
+        Semaine du {debutDeLaSemaine.toLocaleString()} au{' '}
+        {finDeLaSemaine.toLocaleString()}
+      </h2>
+
+      <div className='border border-solid rounded-medium w-full p-4 border-grey_100'>
+        <h3 className='text-m-bold text-content_color mb-4'>Les actions</h3>
+        <ul className='flex gap-2'>
+          <TileIndicateur
+            valeur={indicateursSemaine?.actions.creees.toString() ?? '-'}
+            label={
+              indicateursSemaine?.actions.creees !== 1 ? 'Créées' : 'Créée'
+            }
+            bgColor='primary_lighten'
+            textColor='primary_darken'
+          />
+          <TileIndicateur
+            valeur={indicateursSemaine?.actions.enRetard.toString() ?? '-'}
+            label='En retard'
+            bgColor='alert_lighten'
+            textColor='content_color'
+            iconName={IconName.WarningRounded}
+          />
+          <TileIndicateur
+            valeur={indicateursSemaine?.actions.terminees.toString() ?? '-'}
+            label={
+              indicateursSemaine?.actions.terminees !== 1
+                ? 'Terminées'
+                : 'Terminée'
+            }
+            bgColor='accent_2_lighten'
+            textColor='accent_2'
+            iconName={IconName.RoundedCheck}
+          />
+          <TileIndicateur
+            valeur={indicateursSemaine?.actions.aEcheance.toString() ?? '-'}
+            label='Échéance cette semaine'
+            bgColor='primary_lighten'
+            textColor='primary_darken'
+          />
+        </ul>
+      </div>
+
+      <div className='border border-solid rounded-medium w-full mt-6 p-4 border-grey_100'>
+        <h3 className='text-m-bold text-content_color mb-4'>Les rendez-vous</h3>
+        <ul className='flex'>
+          <TileIndicateur
+            valeur={indicateursSemaine?.rendezVous.toString() ?? '-'}
+            label='Cette semaine'
+            bgColor='primary_lighten'
+            textColor='primary_darken'
+          />
+        </ul>
+      </div>
+
+      <div className='border border-solid rounded-medium w-full mt-6 p-4 border-grey_100'>
+        <h3 className='text-m-bold text-content_color mb-4'>Les offres</h3>
+        <ul className='flex gap-2'>
+          <TileIndicateur
+            valeur={indicateursSemaine?.offres.consultees.toString() ?? '-'}
+            label={
+              indicateursSemaine?.offres.consultees !== 1
+                ? 'Offres consultées'
+                : 'Offre consultée'
+            }
+            bgColor='primary_lighten'
+            textColor='primary_darken'
+          />
+          <TileIndicateur
+            valeur={
+              indicateursSemaine?.favoris.offresSauvegardees.toString() ?? '-'
+            }
+            label={
+              indicateursSemaine?.favoris.offresSauvegardees !== 1
+                ? 'Favoris ajoutés'
+                : 'Favori ajouté'
+            }
+            bgColor='primary_lighten'
+            textColor='primary_darken'
+          />
+          <TileIndicateur
+            valeur={indicateursSemaine?.offres.partagees.toString() ?? '-'}
+            label={
+              indicateursSemaine?.offres.partagees !== 1
+                ? 'Offres partagées'
+                : 'Offre partagée'
+            }
+            bgColor='primary_lighten'
+            textColor='primary_darken'
+          />
+          <TileIndicateur
+            valeur={
+              indicateursSemaine?.favoris.recherchesSauvegardees.toString() ??
+              '-'
+            }
+            label={
+              indicateursSemaine?.favoris.recherchesSauvegardees !== 1
+                ? 'Recherches sauvegardées'
+                : 'Recherche sauvegardée'
+            }
+            bgColor='primary_lighten'
+            textColor='primary_darken'
+          />
+        </ul>
+      </div>
+    </div>
   )
 }
 

--- a/pages/mes-jeunes/[jeune_id]/indicateurs.tsx
+++ b/pages/mes-jeunes/[jeune_id]/indicateurs.tsx
@@ -1,0 +1,85 @@
+import { withTransaction } from '@elastic/apm-rum-react'
+import { DateTime } from 'luxon'
+import { GetServerSideProps } from 'next'
+import React, { useEffect, useState } from 'react'
+
+import { IndicateursJeune } from 'components/jeune/IndicateursJeune'
+import { StructureConseiller } from 'interfaces/conseiller'
+import { IndicateursSemaine } from 'interfaces/jeune'
+import { PageProps } from 'interfaces/pageProps'
+import { JeunesService } from 'services/jeunes.service'
+import { withMandatorySessionOrRedirect } from 'utils/auth/withMandatorySessionOrRedirect'
+import { useDependance } from 'utils/injectionDependances'
+
+type IndicateursProps = PageProps & {
+  idJeune: string
+  idConseiller: string
+}
+
+function Indicateurs({ idJeune, idConseiller }: IndicateursProps) {
+  const jeunesService = useDependance<JeunesService>('jeunesService')
+
+  const [indicateursSemaine, setIndicateursSemaine] = useState<
+    IndicateursSemaine | undefined
+  >()
+
+  const aujourdHui = DateTime.now()
+  const debutDeLaSemaine = aujourdHui.startOf('week')
+  const finDeLaSemaine = aujourdHui.endOf('week')
+
+  // TODO-GAD tracking
+
+  useEffect(() => {
+    if (!indicateursSemaine) {
+      jeunesService
+        .getIndicateursJeune(
+          idConseiller,
+          idJeune,
+          debutDeLaSemaine,
+          finDeLaSemaine
+        )
+        .then(setIndicateursSemaine)
+    }
+  }, [
+    idConseiller,
+    idJeune,
+    debutDeLaSemaine,
+    finDeLaSemaine,
+    indicateursSemaine,
+    jeunesService,
+  ])
+
+  return (
+    <IndicateursJeune
+      debutDeLaSemaine={debutDeLaSemaine}
+      finDeLaSemaine={finDeLaSemaine}
+      indicateursSemaine={indicateursSemaine}
+    />
+  )
+}
+
+export const getServerSideProps: GetServerSideProps<IndicateursProps> = async (
+  context
+) => {
+  const sessionOrRedirect = await withMandatorySessionOrRedirect(context)
+  if (!sessionOrRedirect.validSession) {
+    return { redirect: sessionOrRedirect.redirect }
+  }
+
+  const {
+    session: { user },
+  } = sessionOrRedirect
+  if (user.structure === StructureConseiller.POLE_EMPLOI) {
+    return { notFound: true }
+  }
+
+  return {
+    props: {
+      idJeune: context.query.jeune_id as string,
+      idConseiller: user.id,
+      pageTitle: 'Indicateurs',
+    },
+  }
+}
+
+export default withTransaction(Indicateurs.name, 'page')(Indicateurs)

--- a/setupTests.js
+++ b/setupTests.js
@@ -21,5 +21,4 @@ jest.mock('next/router', () => ({
 
 afterEach(() => {
   cleanup()
-  jest.useRealTimers()
 })

--- a/tests/components/Layout.test.tsx
+++ b/tests/components/Layout.test.tsx
@@ -35,10 +35,6 @@ global.Audio = jest.fn().mockImplementation(() => ({
 }))
 
 describe('<Layout />', () => {
-  beforeEach(() => {
-    jest.useFakeTimers()
-  })
-
   let updateChatsRef: (chats: JeuneChat[]) => void
   const jeunes: JeuneFromListe[] = desItemsJeunes()
   let jeunesChats: JeuneChat[]
@@ -46,7 +42,8 @@ describe('<Layout />', () => {
   let conseillerService: ConseillerService
   let messagesService: MessagesService
   beforeEach(async () => {
-    jest.setSystemTime(DateTime.now().toJSDate())
+    const now = DateTime.now()
+    jest.spyOn(DateTime, 'now').mockReturnValue(now)
 
     jeunesChats = [
       unJeuneChat({

--- a/tests/integration/NotificationsSonores.test.tsx
+++ b/tests/integration/NotificationsSonores.test.tsx
@@ -34,8 +34,8 @@ describe('Intégration notifications sonores', () => {
   let conseillerService: ConseillerService
   let messagesService: MessagesService
   beforeEach(async () => {
-    jest.useFakeTimers()
-    jest.setSystemTime(DateTime.now().toJSDate())
+    const now = DateTime.now()
+    jest.spyOn(DateTime, 'now').mockReturnValue(now)
     ;(useRouter as jest.Mock).mockReturnValue({
       asPath: '/path/to/page',
       route: '/path/to/page',

--- a/tests/pages/FicheJeune.page.test.tsx
+++ b/tests/pages/FicheJeune.page.test.tsx
@@ -349,6 +349,15 @@ describe('Fiche Jeune', () => {
         ).toBeInTheDocument()
       })
 
+      it('affiche un lien vers tous les indicateurs du jeune', async () => {
+        // Then
+        expect(
+          screen.getByRole('link', {
+            name: 'Voir plus d’indicateurs',
+          })
+        ).toHaveAttribute('href', '/mes-jeunes/jeune-1/indicateurs')
+      })
+
       it('affiche la liste des rendez-vous du jeune', async () => {
         // Then
         expect(

--- a/tests/pages/FicheJeune.page.test.tsx
+++ b/tests/pages/FicheJeune.page.test.tsx
@@ -302,6 +302,8 @@ describe('Fiche Jeune', () => {
       let setIdJeune: (id: string | undefined) => void
       beforeEach(async () => {
         // Given
+        const SEPTEMBRE_1 = DateTime.fromISO('2022-09-01T14:00:00.000+02:00')
+        jest.spyOn(DateTime, 'now').mockReturnValue(SEPTEMBRE_1)
         setIdJeune = jest.fn()
 
         // When
@@ -328,6 +330,13 @@ describe('Fiche Jeune', () => {
 
       it('affiche les indicateurs du jeune', async () => {
         // Then
+        const indicateurs = screen.getByRole('heading', {
+          name: 'Les indicateurs de la semaine',
+        }).parentElement
+        expect(
+          within(indicateurs!).getByText('du 29/08/2022 au 04/09/2022')
+        ).toBeInTheDocument()
+
         const indicateursActions = screen.getByRole('heading', {
           name: 'Les actions',
         }).parentElement

--- a/tests/pages/Indicateurs.page.test.tsx
+++ b/tests/pages/Indicateurs.page.test.tsx
@@ -22,8 +22,7 @@ describe('Indicateurs', () => {
 
     beforeEach(async () => {
       // Given
-      jest.useFakeTimers()
-      jest.setSystemTime(SEPTEMBRE_1.toJSDate())
+      jest.spyOn(DateTime, 'now').mockReturnValue(SEPTEMBRE_1)
       const jeunesService = mockedJeunesService({
         getIndicateursJeune: jest.fn(async () => desIndicateursSemaine()),
       })

--- a/tests/pages/Indicateurs.page.test.tsx
+++ b/tests/pages/Indicateurs.page.test.tsx
@@ -22,7 +22,8 @@ describe('Indicateurs', () => {
 
     beforeEach(async () => {
       // Given
-      jest.spyOn(DateTime, 'now').mockReturnValue(SEPTEMBRE_1)
+      jest.useFakeTimers()
+      jest.setSystemTime(SEPTEMBRE_1.toJSDate())
       const jeunesService = mockedJeunesService({
         getIndicateursJeune: jest.fn(async () => desIndicateursSemaine()),
       })
@@ -31,11 +32,7 @@ describe('Indicateurs', () => {
       // Given
       await act(async () => {
         await renderWithContexts(
-          <Indicateurs
-            idJeune='id-jeune'
-            idConseiller='id-conseiller'
-            pageTitle=''
-          />,
+          <Indicateurs idJeune='id-jeune' pageTitle='' />,
           {
             customDependances: { jeunesService },
           }
@@ -45,7 +42,7 @@ describe('Indicateurs', () => {
 
     it('affiche la semaine courante', async () => {
       expect(
-        screen.getByText('Semaine du 8/29/2022 au 9/4/2022')
+        screen.getByText('Semaine du 29/08/2022 au 04/09/2022')
       ).toBeInTheDocument()
     })
 
@@ -118,7 +115,7 @@ describe('Indicateurs', () => {
         ;(withMandatorySessionOrRedirect as jest.Mock).mockResolvedValue({
           validSession: true,
           session: {
-            user: { id: 'id-conseiller', structure: 'MILO' },
+            user: { structure: 'MILO' },
           },
         })
 
@@ -131,7 +128,6 @@ describe('Indicateurs', () => {
         expect(actual).toEqual({
           props: {
             idJeune: 'id-jeune',
-            idConseiller: 'id-conseiller',
             pageTitle: 'Indicateurs',
           },
         })

--- a/tests/pages/Indicateurs.page.test.tsx
+++ b/tests/pages/Indicateurs.page.test.tsx
@@ -1,0 +1,141 @@
+import { act, screen } from '@testing-library/react'
+import { DateTime } from 'luxon'
+import { GetServerSidePropsContext } from 'next/types'
+import React from 'react'
+
+import { desIndicateursSemaine } from 'fixtures/jeune'
+import { mockedJeunesService } from 'fixtures/services'
+import Indicateurs, {
+  getServerSideProps,
+} from 'pages/mes-jeunes/[jeune_id]/indicateurs'
+import { getByTextContent } from 'tests/querySelector'
+import renderWithContexts from 'tests/renderWithContexts'
+import { withMandatorySessionOrRedirect } from 'utils/auth/withMandatorySessionOrRedirect'
+import withDependance from 'utils/injectionDependances/withDependance'
+
+jest.mock('utils/auth/withMandatorySessionOrRedirect')
+jest.mock('utils/injectionDependances/withDependance')
+
+describe('Indicateurs', () => {
+  describe('client side', () => {
+    const SEPTEMBRE_1 = DateTime.fromISO('2022-09-01T14:00:00.000+02:00')
+
+    beforeEach(async () => {
+      // Given
+      jest.spyOn(DateTime, 'now').mockReturnValue(SEPTEMBRE_1)
+      const jeunesService = mockedJeunesService({
+        getIndicateursJeune: jest.fn(async () => desIndicateursSemaine()),
+      })
+      ;(withDependance as jest.Mock).mockReturnValue(jeunesService)
+
+      // Given
+      await act(async () => {
+        await renderWithContexts(
+          <Indicateurs
+            idJeune='id-jeune'
+            idConseiller='id-conseiller'
+            pageTitle=''
+          />,
+          {
+            customDependances: { jeunesService },
+          }
+        )
+      })
+    })
+
+    it('affiche la semaine courante', async () => {
+      expect(
+        screen.getByText('Semaine du 8/29/2022 au 9/4/2022')
+      ).toBeInTheDocument()
+    })
+
+    it('affiche les indicateurs des actions', async () => {
+      const indicateursActions = screen.getByRole('heading', {
+        name: 'Les actions',
+      }).parentElement
+      expect(
+        getByTextContent('0Créées', indicateursActions!)
+      ).toBeInTheDocument()
+      expect(
+        getByTextContent('1Terminée', indicateursActions!)
+      ).toBeInTheDocument()
+      expect(
+        getByTextContent('2En retard', indicateursActions!)
+      ).toBeInTheDocument()
+    })
+
+    it('affiche l’indicateur de rendez-vous', async () => {
+      const indicateursRdv = screen.getByRole('heading', {
+        name: 'Les rendez-vous',
+      }).parentElement
+      expect(
+        getByTextContent('3Cette semaine', indicateursRdv!)
+      ).toBeInTheDocument()
+    })
+
+    it('affiche les indicateurs des offres', async () => {
+      const indicateursOffres = screen.getByRole('heading', {
+        name: 'Les offres',
+      }).parentElement
+      expect(
+        getByTextContent('10Offres consultées', indicateursOffres!)
+      ).toBeInTheDocument()
+      expect(
+        getByTextContent('4Offres partagées', indicateursOffres!)
+      ).toBeInTheDocument()
+      expect(
+        getByTextContent('6Favoris ajoutés', indicateursOffres!)
+      ).toBeInTheDocument()
+      expect(
+        getByTextContent('7Recherches sauvegardées', indicateursOffres!)
+      ).toBeInTheDocument()
+    })
+  })
+
+  describe('server side', () => {
+    describe('Pour un conseiller Pole Emploi', () => {
+      it('renvoie une 404', async () => {
+        // Given
+        ;(withMandatorySessionOrRedirect as jest.Mock).mockResolvedValue({
+          session: {
+            user: { structure: 'POLE_EMPLOI' },
+          },
+          validSession: true,
+        })
+
+        // When
+        const actual = await getServerSideProps({} as GetServerSidePropsContext)
+
+        // Then
+        expect(withMandatorySessionOrRedirect).toHaveBeenCalled()
+        expect(actual).toEqual({ notFound: true })
+      })
+    })
+
+    describe('quand le conseiller est connecté', () => {
+      it('récupère le titre de la page, et les id du jeune et du conseiller', async () => {
+        // Given
+        ;(withMandatorySessionOrRedirect as jest.Mock).mockResolvedValue({
+          validSession: true,
+          session: {
+            user: { id: 'id-conseiller', structure: 'MILO' },
+          },
+        })
+
+        // When
+        const actual = await getServerSideProps({
+          query: { jeune_id: 'id-jeune' },
+        } as unknown as GetServerSidePropsContext)
+
+        // Then
+        expect(actual).toEqual({
+          props: {
+            idJeune: 'id-jeune',
+            idConseiller: 'id-conseiller',
+            pageTitle: 'Indicateurs',
+          },
+        })
+      })
+    })
+  })
+})

--- a/tests/services/messages.service.test.ts
+++ b/tests/services/messages.service.test.ts
@@ -25,10 +25,6 @@ jest.mock('next-auth/react', () => ({
 }))
 
 describe('MessagesFirebaseAndApiService', () => {
-  beforeEach(async () => {
-    jest.useFakeTimers()
-  })
-
   let firebaseClient: FirebaseClient
   let apiClient: ApiClient
   let messagesService: MessagesFirebaseAndApiService
@@ -75,7 +71,7 @@ describe('MessagesFirebaseAndApiService', () => {
     it('updates chat in firebase', async () => {
       // Given
       const now = DateTime.now()
-      jest.setSystemTime(now.toJSDate())
+      jest.spyOn(DateTime, 'now').mockReturnValue(now)
       const jeuneChat = unJeuneChat()
 
       // When
@@ -108,7 +104,8 @@ describe('MessagesFirebaseAndApiService', () => {
     let updateChats: (chats: Chat[]) => void
     beforeEach(async () => {
       // Given
-      jest.setSystemTime(DateTime.now().toJSDate())
+      const now = DateTime.now()
+      jest.spyOn(DateTime, 'now').mockReturnValue(now)
       updateChats = jest.fn()
 
       // When
@@ -246,7 +243,7 @@ describe('MessagesFirebaseAndApiService', () => {
     const now = DateTime.now()
     beforeEach(async () => {
       // Given
-      jest.setSystemTime(now.toJSDate())
+      jest.spyOn(DateTime, 'now').mockReturnValue(now)
       jeuneChat = unJeuneChat()
       newMessage = 'nouveauMessage'
       // When
@@ -365,7 +362,7 @@ describe('MessagesFirebaseAndApiService', () => {
     const now = DateTime.now()
     beforeEach(async () => {
       // Given
-      jest.setSystemTime(now.toJSDate())
+      jest.spyOn(DateTime, 'now').mockReturnValue(now)
       destinataires = desItemsJeunes()
       idsJeunes = destinataires.map(({ id }) => id)
       newMessageGroupe = 'nouveau message groupé'

--- a/tests/utils/authenticator.test.ts
+++ b/tests/utils/authenticator.test.ts
@@ -16,9 +16,8 @@ describe('Authenticator', () => {
   beforeEach(() => {
     httpClient = { fetchJson: jest.fn(), fetchNoContent: jest.fn() }
     authenticator = new Authenticator(httpClient)
-    jest.useFakeTimers()
     now = DateTime.now()
-    jest.setSystemTime(now.toJSDate())
+    jest.spyOn(DateTime, 'now').mockReturnValue(now)
 
     accessToken =
       'eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJleGItdTZsMmNkS1BzWEdRUXJIb0tIS0lVS2NmbE9xUkcyYTE0QjNWSzRVIn0.eyJleHAiOjE2NDYwMzkwMjgsImlhdCI6MTY0NjAzNzIyOCwiYXV0aF90aW1lIjoxNjQ2MDM3MjI4LCJqdGkiOiI4MmQwOWI2Zi00NjFmLTQ2OWEtODk0Yy01NDYzMmE2NmU5YzUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODIvYXV0aC9yZWFsbXMvcGFzcy1lbXBsb2kiLCJzdWIiOiI4NDNkYzljZS1jMWVlLTRmYjUtODYwMy1hYjI3MzEwMzY0N2QiLCJ0eXAiOiJCZWFyZXIiLCJhenAiOiJwYXNzLWVtcGxvaS13ZWIiLCJzZXNzaW9uX3N0YXRlIjoiYTIyZjY3OWYtZmFjZi00ZTgzLWEwZjgtYjI0YzBkMzJjNGZiIiwiYWNyIjoiMSIsInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJjb25zZWlsbGVyX3N1cGVydmlzZXVyIl19LCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwYXNzLWVtcGxvaS11c2VyIHByb2ZpbGUiLCJzaWQiOiJhMjJmNjc5Zi1mYWNmLTRlODMtYTBmOC1iMjRjMGQzMmM0ZmIiLCJ1c2VyUm9sZXMiOlsiU1VQRVJWSVNFVVIiXSwiZW1haWxfdmVyaWZpZWQiOmZhbHNlLCJ1c2VyU3RydWN0dXJlIjoiUEFTU19FTVBMT0kiLCJuYW1lIjoiTmlscyBUYXZlcm5pZXIiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiI0MSIsInVzZXJUeXBlIjoiQ09OU0VJTExFUiIsImdpdmVuX25hbWUiOiJOaWxzIiwidXNlcklkIjoiNDEiLCJmYW1pbHlfbmFtZSI6IlRhdmVybmllciIsImVtYWlsIjoibmlscy50YXZlcm5pZXJAcGFzc2VtcGxvaS5jb20ifQ.TdAdafg4EVyJkTaBfEiFLjsGjWyAkFgIcBfB72tmYc6uVWvy49u5RJIkqVk60OEjsGX6bfSW_lbAp8nR1tpfVMV_rAHCFnnk3nw2dh-Qp2jmNfvlxY5v1m_KouK-7_XB6xJ-M7-Q2EUQmRn5XFJ31Pka7JaSCaCHae7W-juE4Ocko2eEbYV24OtRqRYXLlAS3WPR9vVufVwRp-hQYghdQ9WvAsdPzGW9yqnl5FlA7ITx_ad8OwCIQtFznXqzXYVq9bqfBqnsxz6lb9KHhL5EGIjqaWxzxLeIZ44Ag3R1hUhDOZYaw2qD1VMu2HnhDqESCiCoYTYRKasKCsyaSFKZ-A'
@@ -61,7 +60,6 @@ describe('Authenticator', () => {
     describe("Quand ce n'est pas la première connexion", () => {
       it('renvoie le JWT', async () => {
         // When
-        const vingtSEnMs = 20000
         const jwt = {
           ...jwtFixture(),
           expiresAtTimestamp: now.plus({ second: 20 }).toMillis(),
@@ -111,7 +109,6 @@ describe('Authenticator', () => {
 
       describe("si l'access token expire dans moins de 15 secondes", () => {
         it('utilise le refresh token pour récupérer un nouvel access token', async () => {
-          const treizeSenMs = 13000
           // Given
           const jwt = {
             ...jwtFixture(),

--- a/tests/utils/date.test.ts
+++ b/tests/utils/date.test.ts
@@ -15,16 +15,12 @@ import {
 } from 'utils/date'
 
 describe('dateUtils', () => {
-  beforeEach(() => {
-    jest.useFakeTimers()
-  })
-
   describe('dateIsToday', () => {
     it("dateIsToday renvoie true si la date correspond à la date d'aujourd'hui", () => {
       //GIVEN
-      jest.setSystemTime(
-        DateTime.fromISO('2018-12-31T13:59:59.000Z').toJSDate()
-      )
+      jest
+        .spyOn(DateTime, 'now')
+        .mockReturnValue(DateTime.fromISO('2018-12-31T13:59:59.000Z'))
 
       //THEN
       expect(dateIsToday(DateTime.fromISO('2018-12-31T22:59:59.000Z'))).toEqual(
@@ -39,9 +35,9 @@ describe('dateUtils', () => {
   describe('dateIsYesterday', () => {
     it("dateIsYesterday renvoie true si la date correspond à la date d'hier", () => {
       //GIVEN
-      jest.setSystemTime(
-        DateTime.fromISO('2018-12-31T13:59:59.000Z').toJSDate()
-      )
+      jest
+        .spyOn(DateTime, 'now')
+        .mockReturnValue(DateTime.fromISO('2018-12-31T13:59:59.000Z'))
 
       //THEN
       expect(

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -1,4 +1,4 @@
-import { DateTime } from 'luxon'
+import { DateTime, DateTimeFormatOptions } from 'luxon'
 
 export const WEEKDAY_MONTH_LONG: string = 'EEEE d MMMM'
 export const TIME_24_H_SEPARATOR: string = "HH'h'mm"
@@ -14,9 +14,16 @@ export function dateIsYesterday(dateToCheck: DateTime): boolean {
   return DateTime.now().minus({ day: 1 }).hasSame(dateToCheck, 'day')
 }
 
+export function toFrenchString(
+  datetime: DateTime,
+  format?: DateTimeFormatOptions
+): string {
+  return datetime.toLocaleString(format, { locale: 'fr-FR' })
+}
+
 export function toShortDate(date: string | DateTime): string {
   const datetime = date instanceof DateTime ? date : DateTime.fromISO(date)
-  return datetime.toLocaleString(DateTime.DATE_SHORT, { locale: 'fr-FR' })
+  return toFrenchString(datetime, DateTime.DATE_SHORT)
 }
 
 export function toFrenchFormat(date: DateTime, format: string): string {


### PR DESCRIPTION
Lien vers le [Notion](https://www.notion.so/fabnummas/Afficher-le-d-tail-indicateurs-pour-le-conseiller-332317e573f642abb9167fa5338ef5fa)

- [x] MAJ model + repo
- [x] Mise en place de la page
- [x] Layout
- [x] Peaufinage layout
- [x] Fil d'ariane
- [x] Tracking
- [x] Test
- [x] Lien vers la page
- [ ] Erreur Next / React (déjà présent dans la version actuelle)

Vu avec @arthurlbrjc : l'erreur Next fait l'objet d'un ticket tech à part [dans la pioche](https://trello.com/c/SorcmTiS/1007-wtf-with-doublon-email-conseiller).