### PR TITLE
fix(US-1414): Revert "Feat/us 1415 wording formulaire de qualification des snp"

### DIFF
--- a/pages/mes-jeunes/[jeune_id]/actions/[action_id]/qualification.tsx
+++ b/pages/mes-jeunes/[jeune_id]/actions/[action_id]/qualification.tsx
@@ -137,14 +137,14 @@ function PageQualification({
           <span className='hover:text-primary_darken'>
             <ExternalLink
               href='https://c-milo.i-milo.fr/jcms/t482_1002488/fr/mentions-legales'
-              label='Voir le détail des CGU'
+              label='voir le détail des CGU'
               onClick={() => setLabelMatomo('Lien CGU')}
             />
           </span>
           <span className='hover:text-primary_darken'>
             <ExternalLink
               href='https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000045084361'
-              label='Voir le détail de l’arrêté du 17 novembre 2021'
+              label='voir le détail de l’arrêté du 17 novembre 2021'
               onClick={() => setLabelMatomo('Lien Arrêté 17 novembre 2021')}
             />
           </span>

--- a/tests/pages/Qualification.page.test.tsx
+++ b/tests/pages/Qualification.page.test.tsx
@@ -239,7 +239,7 @@ describe("Page Qualification d'une action", () => {
       ).toBeInTheDocument()
       expect(
         screen.getByRole('link', {
-          name: 'Voir le détail des CGU (nouvelle fenêtre)',
+          name: 'voir le détail des CGU (nouvelle fenêtre)',
         })
       ).toHaveAttribute(
         'href',
@@ -247,12 +247,9 @@ describe("Page Qualification d'une action", () => {
       )
       expect(
         screen.getByRole('link', {
-          name: 'Voir le détail de l’arrêté du 17 novembre 2021 (nouvelle fenêtre)',
+          name: 'voir le détail de l’arrêté du 17 novembre 2021 (nouvelle fenêtre)',
         })
-      ).toHaveAttribute(
-        'href',
-        'https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000045084361'
-      )
+      ).toHaveAttribute('href', 'https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000045084361')
     })
 
     it("affiche le résumé de l'action", () => {


### PR DESCRIPTION
En attente activation des commentaires par i-Milo pour mettre en prod cette feature, on retire les modifications concernant le formulaire de qualification d'une action en SNP

cf. https://mattermost.incubateur.net/spie/pl/q9hyzu94ffn4uefriasn518ezh