### PR TITLE
CTA in header

### DIFF
--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -13,6 +13,8 @@ import IconComponent, { IconName } from './ui/IconComponent'
 
 import styles from 'styles/components/Modal.module.css'
 
+export const MODAL_ROOT_ID = 'modal-root'
+
 interface ModalProps {
   title: string
   onClose: () => void
@@ -133,7 +135,7 @@ const Modal = forwardRef((props: ModalProps, ref) => {
   )
 
   if (isBrowser) {
-    const modalRoot = document.getElementById('modal-root')
+    const modalRoot = document.getElementById(MODAL_ROOT_ID)
     return modalRoot ? createPortal(modalContainer, modalRoot) : null
   } else {
     return null

--- a/components/PageActionsPortal.tsx
+++ b/components/PageActionsPortal.tsx
@@ -1,0 +1,29 @@
+import { ReactElement, useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+export const PAGE_ACTIONS_ROOT_ID = 'page-actions-root'
+
+type PageActionsPortalProps = {
+  children: ReactElement | ReactElement[]
+}
+
+export default function PageActionsPortal({
+  children,
+}: PageActionsPortalProps) {
+  const [isBrowser, setIsBrowser] = useState(false)
+
+  const pageActionsContainer = <>{children}</>
+
+  useEffect(() => {
+    setIsBrowser(true)
+  }, [])
+
+  if (isBrowser) {
+    const pageActionsRoot = document.getElementById(PAGE_ACTIONS_ROOT_ID)
+    return pageActionsRoot
+      ? createPortal(pageActionsContainer, pageActionsRoot)
+      : null
+  } else {
+    return null
+  }
+}

--- a/components/__mocks__/PageActionsPortal.tsx
+++ b/components/__mocks__/PageActionsPortal.tsx
@@ -1,0 +1,5 @@
+import { ReactNode } from 'react'
+
+export default function FakePortal(props: { children: ReactNode }) {
+  return <>{props.children}</>
+}

--- a/components/jeune/BlocInformationJeune.tsx
+++ b/components/jeune/BlocInformationJeune.tsx
@@ -1,7 +1,6 @@
 import Link from 'next/link'
-import React, { MouseEventHandler, useMemo } from 'react'
+import React, { useMemo } from 'react'
 
-import Button, { ButtonStyle } from 'components/ui/Button/Button'
 import IconComponent, { IconName } from 'components/ui/IconComponent'
 import { StructureConseiller } from 'interfaces/conseiller'
 import { toShortDate } from 'utils/date'
@@ -17,7 +16,6 @@ interface BlocInformationJeuneProps {
   onIdentifiantPartenaireClick: () => void
   urlDossier: string | undefined
   onDossierMiloClick: () => void
-  onDeleteJeuneClick: MouseEventHandler<HTMLButtonElement>
 }
 
 export function BlocInformationJeune({
@@ -31,7 +29,6 @@ export function BlocInformationJeune({
   onIdentifiantPartenaireClick,
   urlDossier,
   onDossierMiloClick,
-  onDeleteJeuneClick,
 }: BlocInformationJeuneProps) {
   const shortCreationDate = useMemo(
     () => toShortDate(creationDate),
@@ -75,13 +72,9 @@ export function BlocInformationJeune({
         )}
       </dl>
 
-      <div className='flex flex-row justify-between items-end mt-4'>
-        <BouttonSupprimerCompte onClick={onDeleteJeuneClick} />
-
-        {structureConseiller !== StructureConseiller.MILO && (
-          <LienVersHistorique idJeune={idJeune} />
-        )}
-      </div>
+      {structureConseiller !== StructureConseiller.MILO && (
+        <LienVersHistorique idJeune={idJeune} />
+      )}
     </div>
   )
 }
@@ -163,22 +156,6 @@ function DossierExterne(props: { href: string; onClick: () => void }) {
         </a>
       </dd>
     </>
-  )
-}
-
-function BouttonSupprimerCompte(props: {
-  onClick: (event: React.MouseEvent<HTMLButtonElement>) => void
-}) {
-  return (
-    <Button onClick={props.onClick} style={ButtonStyle.SECONDARY}>
-      <IconComponent
-        name={IconName.Trashcan}
-        focusable={false}
-        aria-hidden={true}
-        className='mr-2 w-4 h-4'
-      />
-      Supprimer ce compte
-    </Button>
   )
 }
 

--- a/components/jeune/DetailsJeune.tsx
+++ b/components/jeune/DetailsJeune.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEventHandler, useState } from 'react'
+import React, { useState } from 'react'
 
 import { BlocInformationJeune } from 'components/jeune/BlocInformationJeune'
 import { BlocSituation } from 'components/jeune/BlocSituation'
@@ -15,14 +15,12 @@ interface DetailsJeuneProps {
   jeune: DetailJeune
   structureConseiller: StructureConseiller | undefined
   onDossierMiloClick: () => void
-  onDeleteJeuneClick: MouseEventHandler<HTMLButtonElement>
 }
 
 export const DetailsJeune = ({
   jeune,
   structureConseiller,
   onDossierMiloClick,
-  onDeleteJeuneClick,
 }: DetailsJeuneProps) => {
   const jeunesService = useDependance<JeunesService>('jeunesService')
   const [_, setAlerte] = useAlerte()
@@ -87,7 +85,6 @@ export const DetailsJeune = ({
           onIdentifiantPartenaireClick={openIdentifiantPartenaireModal}
           urlDossier={jeune.urlDossier}
           onDossierMiloClick={onDossierMiloClick}
-          onDeleteJeuneClick={onDeleteJeuneClick}
         />
       </div>
 

--- a/components/layouts/Header.tsx
+++ b/components/layouts/Header.tsx
@@ -1,6 +1,8 @@
+import React from 'react'
+
 import FilAriane from 'components/FilAriane'
 import LienRetour from 'components/LienRetour'
-import styles from 'styles/components/Layouts.module.css'
+import { PAGE_ACTIONS_ROOT_ID } from 'components/PageActionsPortal'
 
 interface HeaderProps {
   currentPath: string
@@ -10,20 +12,22 @@ interface HeaderProps {
 
 export function Header({ currentPath, pageHeader, returnTo }: HeaderProps) {
   return (
-    <header className={styles.header}>
+    <header className='flex justify-between px-8 py-12 border-b border-solid border-primary_lighten'>
       {!returnTo && (
-        <>
+        <div>
           <FilAriane currentPath={currentPath} />
           <h1 className='text-l-bold text-primary'>{pageHeader}</h1>
-        </>
+        </div>
       )}
 
       {returnTo && (
-        <>
+        <div>
           <LienRetour returnUrlOrPath={returnTo} />
           <h1 className='text-l-bold text-primary'>{pageHeader}</h1>
-        </>
+        </div>
       )}
+
+      <div id={PAGE_ACTIONS_ROOT_ID} />
     </header>
   )
 }

--- a/components/layouts/Header.tsx
+++ b/components/layouts/Header.tsx
@@ -12,7 +12,7 @@ interface HeaderProps {
 
 export function Header({ currentPath, pageHeader, returnTo }: HeaderProps) {
   return (
-    <header className='flex justify-between px-8 py-12 border-b border-solid border-primary_lighten'>
+    <header className='flex justify-between items-center px-12 py-8 border-b border-solid border-primary_lighten'>
       {!returnTo && (
         <div>
           <FilAriane currentPath={currentPath} />

--- a/components/layouts/Header.tsx
+++ b/components/layouts/Header.tsx
@@ -27,7 +27,7 @@ export function Header({ currentPath, pageHeader, returnTo }: HeaderProps) {
         </div>
       )}
 
-      <div id={PAGE_ACTIONS_ROOT_ID} />
+      <div id={PAGE_ACTIONS_ROOT_ID} className='flex gap-6' />
     </header>
   )
 }

--- a/components/layouts/Layout.tsx
+++ b/components/layouts/Layout.tsx
@@ -12,6 +12,7 @@ import ChatManager from 'components/layouts/ChatManager'
 import Footer from 'components/layouts/Footer'
 import { Header } from 'components/layouts/Header'
 import Sidebar from 'components/layouts/Sidebar'
+import { MODAL_ROOT_ID } from 'components/Modal'
 import { PageProps } from 'interfaces/pageProps'
 import { ConseillerService } from 'services/conseiller.service'
 import styles from 'styles/components/Layouts.module.css'
@@ -107,7 +108,7 @@ export default function Layout({ children }: LayoutProps) {
           setHasMessageNonLu={setHasMessageNonLu}
         />
       </div>
-      <div id='modal-root' />
+      <div id={MODAL_ROOT_ID} />
     </>
   )
 }

--- a/components/offres/ImmersionDetail.tsx
+++ b/components/offres/ImmersionDetail.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import LienPartageOffre from 'components/offres/LienPartageOffre'
+import PageActionsPortal from 'components/PageActionsPortal'
 import { ButtonStyle } from 'components/ui/Button/Button'
 import IconComponent, { IconName } from 'components/ui/IconComponent'
 import { DataTag } from 'components/ui/Indicateurs/DataTag'
@@ -12,103 +13,106 @@ type ImmersionDetailProps = {
 
 export default function ImmersionDetail({ offre }: ImmersionDetailProps) {
   return (
-    <div className='max-w-2xl mx-auto'>
-      <div className='flex justify-end mb-6'>
+    <>
+      <PageActionsPortal>
         <LienPartageOffre
           titreOffre={offre.titre}
           href={`/offres/immersion/${offre.id}/partage`}
           style={ButtonStyle.PRIMARY}
         />
-      </div>
-      <h2 className='text-l-bold text-primary'>{offre.titre}</h2>
+      </PageActionsPortal>
 
-      <section aria-labelledby='heading-info' className='mt-6'>
-        <h3 id='heading-info' className='sr-only'>
-          Informations de l&apos;offre
-        </h3>
+      <div className='max-w-2xl mx-auto'>
+        <h2 className='text-l-bold text-primary'>{offre.titre}</h2>
 
-        <dl>
-          <dt className='sr-only'>Établissement</dt>
-          <dd>{offre.nomEtablissement}</dd>
+        <section aria-labelledby='heading-info' className='mt-6'>
+          <h3 id='heading-info' className='sr-only'>
+            Informations de l&apos;offre
+          </h3>
 
-          <dt className='sr-only'>Secteur d’activité</dt>
-          <dd className='mt-6'>
-            <DataTag text={offre.secteurActivite} />
-          </dd>
+          <dl>
+            <dt className='sr-only'>Établissement</dt>
+            <dd>{offre.nomEtablissement}</dd>
 
-          <dt className='sr-only'>Ville</dt>
-          <dd className='mt-2'>
-            <DataTag text={offre.ville} iconName={IconName.Location} />
-          </dd>
-        </dl>
+            <dt className='sr-only'>Secteur d’activité</dt>
+            <dd className='mt-6'>
+              <DataTag text={offre.secteurActivite} />
+            </dd>
 
-        <p className='mt-8'>
-          Cette entreprise peut recruter sur ce métier et être intéressée pour
-          vous vous recevoir en immersion. Contactez-la en expliquant votre
-          projet professionnel et vos motivations.
-        </p>
-        <p className='mt-2'>
-          Si l’entreprise est d’accord pour vous accueillir :
-        </p>
-        <ul className='mt-2 list-disc list-inside'>
-          <li>Prévenez votre conseiller</li>
-          <li>Remplissez une convention d’immersion avec lui</li>
-        </ul>
-      </section>
+            <dt className='sr-only'>Ville</dt>
+            <dd className='mt-2'>
+              <DataTag text={offre.ville} iconName={IconName.Location} />
+            </dd>
+          </dl>
 
-      <section aria-labelledby='heading-contact' className='mt-8'>
-        <h3
-          id='heading-contact'
-          className={
-            'inline-flex items-center w-full text-m-bold text-grey_800 pb-6 border-b border-solid border-primary_lighten'
-          }
-        >
-          <SectionTitleDot />
-          <span className='sr-only'>Informations du </span>Contact
-        </h3>
+          <p className='mt-8'>
+            Cette entreprise peut recruter sur ce métier et être intéressée pour
+            vous vous recevoir en immersion. Contactez-la en expliquant votre
+            projet professionnel et vos motivations.
+          </p>
+          <p className='mt-2'>
+            Si l’entreprise est d’accord pour vous accueillir :
+          </p>
+          <ul className='mt-2 list-disc list-inside'>
+            <li>Prévenez votre conseiller</li>
+            <li>Remplissez une convention d’immersion avec lui</li>
+          </ul>
+        </section>
 
-        <dl>
-          {(offre.contact.prenom ||
-            offre.contact.nom ||
-            offre.contact.role) && (
-            <div className='mt-8 text-base-bold'>
+        <section aria-labelledby='heading-contact' className='mt-8'>
+          <h3
+            id='heading-contact'
+            className={
+              'inline-flex items-center w-full text-m-bold text-grey_800 pb-6 border-b border-solid border-primary_lighten'
+            }
+          >
+            <SectionTitleDot />
+            <span className='sr-only'>Informations du </span>Contact
+          </h3>
+
+          <dl>
+            {(offre.contact.prenom ||
+              offre.contact.nom ||
+              offre.contact.role) && (
+              <div className='mt-8 text-base-bold'>
+                <>
+                  {(offre.contact.prenom || offre.contact.nom) && (
+                    <>
+                      <dt className='sr-only'>Interlocuteur</dt>
+                      <dd>
+                        {offre.contact.prenom} {offre.contact.nom}
+                      </dd>
+                    </>
+                  )}
+                  {offre.contact.role && (
+                    <>
+                      <dt className='sr-only'>Rôle</dt>
+                      <dd>{offre.contact.role}</dd>
+                    </>
+                  )}
+                </>
+              </div>
+            )}
+
+            <dt className='sr-only'>Adresse</dt>
+            <dd className='mt-8'>{offre.contact.adresse}</dd>
+
+            {offre.contact.email && (
               <>
-                {(offre.contact.prenom || offre.contact.nom) && (
-                  <>
-                    <dt className='sr-only'>Interlocuteur</dt>
-                    <dd>
-                      {offre.contact.prenom} {offre.contact.nom}
-                    </dd>
-                  </>
-                )}
-                {offre.contact.role && (
-                  <>
-                    <dt className='sr-only'>Rôle</dt>
-                    <dd>{offre.contact.role}</dd>
-                  </>
-                )}
+                <dt className='sr-only'>E-mail</dt>
+                <dd className='mt-8'>{offre.contact.email}</dd>
               </>
-            </div>
-          )}
-
-          <dt className='sr-only'>Adresse</dt>
-          <dd className='mt-8'>{offre.contact.adresse}</dd>
-
-          {offre.contact.email && (
-            <>
-              <dt className='sr-only'>E-mail</dt>
-              <dd className='mt-8'>{offre.contact.email}</dd>
-            </>
-          )}
-          {offre.contact.telephone && (
-            <>
-              <dt className='sr-only'>Téléphone</dt>
-              <dd className='mt-8'>{offre.contact.telephone}</dd>
-            </>
-          )}
-        </dl>
-      </section>
-    </div>
+            )}
+            {offre.contact.telephone && (
+              <>
+                <dt className='sr-only'>Téléphone</dt>
+                <dd className='mt-8'>{offre.contact.telephone}</dd>
+              </>
+            )}
+          </dl>
+        </section>
+      </div>
+    </>
   )
 }
 

--- a/components/offres/OffreEmploiDetail.tsx
+++ b/components/offres/OffreEmploiDetail.tsx
@@ -2,6 +2,7 @@ import { DateTime } from 'luxon'
 import React from 'react'
 
 import LienPartageOffre from 'components/offres/LienPartageOffre'
+import PageActionsPortal from 'components/PageActionsPortal'
 import { ButtonStyle } from 'components/ui/Button/Button'
 import IconComponent, { IconName } from 'components/ui/IconComponent'
 import { DataTag } from 'components/ui/Indicateurs/DataTag'
@@ -50,262 +51,267 @@ export default function OffreEmploiDetail({
   const liStyle = 'mb-4 last:mb-0'
 
   return (
-    <div className='max-w-2xl mx-auto'>
-      <div className='flex justify-between items-center mb-6'>
-        <p className='text-s-regular'>
-          {dateActualisation ? 'Actualisée le ' + dateActualisation : ''}
-        </p>
+    <>
+      <PageActionsPortal>
         <LienPartageOffre
           titreOffre={offre.titre}
           href={`/offres/emploi/${offre.id}/partage`}
           style={ButtonStyle.PRIMARY}
         />
-      </div>
-      <h2 className='text-l-bold text-primary'>{offre.titre}</h2>
+      </PageActionsPortal>
 
-      <section aria-labelledby='heading-info' className='mt-6'>
-        <h3 id='heading-info' className='sr-only'>
-          Informations de l&apos;offre
-        </h3>
+      <div className='max-w-2xl mx-auto'>
+        <p className='text-s-regular mb-2'>
+          {dateActualisation ? 'Actualisée le ' + dateActualisation : ''}
+        </p>
+        <h2 className='text-l-bold text-primary'>{offre.titre}</h2>
 
-        <dl>
-          {offre.nomEntreprise && (
-            <>
-              <dt className='sr-only'>Entreprise</dt>
-              <dd>{offre.nomEntreprise}</dd>
-            </>
-          )}
-
-          {offre.localisation && (
-            <>
-              <dt className='sr-only'>Localisation</dt>
-              <dd className='mt-6'>
-                <DataTag
-                  text={offre.localisation}
-                  iconName={IconName.Location}
-                />
-              </dd>
-            </>
-          )}
-
-          <dt className='sr-only'>Type de contrat</dt>
-          <dd className='mt-2'>
-            <DataTag
-              text={offre.typeContratLibelle}
-              iconName={IconName.Contrat}
-            />
-          </dd>
-
-          {offre.salaire && (
-            <>
-              <dt className='sr-only'>Salaire</dt>
-              <dd className='mt-2'>
-                <DataTag text={offre.salaire} iconName={IconName.Euro} />
-              </dd>
-            </>
-          )}
-
-          {offre.horaires && (
-            <>
-              <dt className='sr-only'>Horaires</dt>
-              <dd className='mt-2'>
-                <DataTag text={offre.horaires} iconName={IconName.Clock} />
-              </dd>
-            </>
-          )}
-        </dl>
-      </section>
-
-      {hasDetail && (
-        <section aria-labelledby='heading-detail' className='mt-8'>
-          <h3 id='heading-detail' className={sectionTitleStyle}>
-            <SectionTitleDot />
-            Détail de l’offre
+        <section aria-labelledby='heading-info' className='mt-6'>
+          <h3 id='heading-info' className='sr-only'>
+            Informations de l&apos;offre
           </h3>
 
           <dl>
-            {offre.description && (
+            {offre.nomEntreprise && (
               <>
-                <dt className='sr-only'>Description</dt>
-                <dd className={`${ddStyle} whitespace-pre-wrap`}>
-                  {offre.description}
+                <dt className='sr-only'>Entreprise</dt>
+                <dd>{offre.nomEntreprise}</dd>
+              </>
+            )}
+
+            {offre.localisation && (
+              <>
+                <dt className='sr-only'>Localisation</dt>
+                <dd className='mt-6'>
+                  <DataTag
+                    text={offre.localisation}
+                    iconName={IconName.Location}
+                  />
                 </dd>
               </>
             )}
-            {offre.urlPostulation && (
+
+            <dt className='sr-only'>Type de contrat</dt>
+            <dd className='mt-2'>
+              <DataTag
+                text={offre.typeContratLibelle}
+                iconName={IconName.Contrat}
+              />
+            </dd>
+
+            {offre.salaire && (
               <>
-                <dt className='sr-only'>Lien offre</dt>
-                <dd
-                  className={`${ddStyle} text-primary hover:text-primary_darken`}
-                >
-                  <ExternalLink
-                    href={offre.urlPostulation}
-                    label="Voir l'offre détaillée"
-                    onClick={() => onLienExterne('Lien Offre externe')}
-                  />
+                <dt className='sr-only'>Salaire</dt>
+                <dd className='mt-2'>
+                  <DataTag text={offre.salaire} iconName={IconName.Euro} />
+                </dd>
+              </>
+            )}
+
+            {offre.horaires && (
+              <>
+                <dt className='sr-only'>Horaires</dt>
+                <dd className='mt-2'>
+                  <DataTag text={offre.horaires} iconName={IconName.Clock} />
                 </dd>
               </>
             )}
           </dl>
         </section>
-      )}
 
-      {hasProfil && (
-        <section aria-labelledby='heading-profil' className='mt-6'>
-          <h3 id='heading-profil' className={sectionTitleStyle}>
-            <SectionTitleDot />
-            Profil souhaité
-          </h3>
+        {hasDetail && (
+          <section aria-labelledby='heading-detail' className='mt-8'>
+            <h3 id='heading-detail' className={sectionTitleStyle}>
+              <SectionTitleDot />
+              Détail de l’offre
+            </h3>
 
-          <dl>
-            {offre.experience && (
-              <>
-                <dt className={dtStyle}>Expériences</dt>
-                <dd className={`${ddStyle} flex`}>
-                  {offre.experience.libelle}
-                  {offre.experience.exigee && (
-                    <IconComponent
-                      name={IconName.Important}
-                      title='Expérience exigée'
-                      aria-label='Expérience exigée'
-                      focusable={false}
-                      aria-hidden={true}
-                      className='inline ml-2 h-5 w-5 fill-primary'
+            <dl>
+              {offre.description && (
+                <>
+                  <dt className='sr-only'>Description</dt>
+                  <dd className={`${ddStyle} whitespace-pre-wrap`}>
+                    {offre.description}
+                  </dd>
+                </>
+              )}
+              {offre.urlPostulation && (
+                <>
+                  <dt className='sr-only'>Lien offre</dt>
+                  <dd
+                    className={`${ddStyle} text-primary hover:text-primary_darken`}
+                  >
+                    <ExternalLink
+                      href={offre.urlPostulation}
+                      label="Voir l'offre détaillée"
+                      onClick={() => onLienExterne('Lien Offre externe')}
                     />
-                  )}
-                </dd>
-              </>
-            )}
+                  </dd>
+                </>
+              )}
+            </dl>
+          </section>
+        )}
 
-            {offre.competences.length > 0 && (
-              <>
-                <dt className={dtStyle}>Savoir et savoir faire</dt>
-                <dd className={ddStyle}>
-                  <ul className={ulStyle}>
-                    {offre.competences.map((competence) => (
-                      <li key={competence} className={liStyle}>
-                        {competence}
-                      </li>
-                    ))}
-                  </ul>
-                </dd>
-              </>
-            )}
+        {hasProfil && (
+          <section aria-labelledby='heading-profil' className='mt-6'>
+            <h3 id='heading-profil' className={sectionTitleStyle}>
+              <SectionTitleDot />
+              Profil souhaité
+            </h3>
 
-            {offre.competencesProfessionnelles.length > 0 && (
-              <>
-                <dt className={dtStyle}>Savoir être professionnel</dt>
-                <dd className={ddStyle}>
-                  <ul className={ulStyle}>
-                    {offre.competencesProfessionnelles.map((competencePro) => (
-                      <li key={competencePro} className={liStyle}>
-                        {competencePro}
-                      </li>
-                    ))}
-                  </ul>
-                </dd>
-              </>
-            )}
+            <dl>
+              {offre.experience && (
+                <>
+                  <dt className={dtStyle}>Expériences</dt>
+                  <dd className={`${ddStyle} flex`}>
+                    {offre.experience.libelle}
+                    {offre.experience.exigee && (
+                      <IconComponent
+                        name={IconName.Important}
+                        title='Expérience exigée'
+                        aria-label='Expérience exigée'
+                        focusable={false}
+                        aria-hidden={true}
+                        className='inline ml-2 h-5 w-5 fill-primary'
+                      />
+                    )}
+                  </dd>
+                </>
+              )}
 
-            {offre.formations.length > 0 && (
-              <>
-                <dt className={dtStyle}>Formation</dt>
-                <dd className={ddStyle}>
-                  <ul className={ulStyle}>
-                    {offre.formations.map((formation) => (
-                      <li key={formation} className={liStyle}>
-                        {formation}
-                      </li>
-                    ))}
-                  </ul>
-                </dd>
-              </>
-            )}
+              {offre.competences.length > 0 && (
+                <>
+                  <dt className={dtStyle}>Savoir et savoir faire</dt>
+                  <dd className={ddStyle}>
+                    <ul className={ulStyle}>
+                      {offre.competences.map((competence) => (
+                        <li key={competence} className={liStyle}>
+                          {competence}
+                        </li>
+                      ))}
+                    </ul>
+                  </dd>
+                </>
+              )}
 
-            {offre.langues.length > 0 && (
-              <>
-                <dt className={dtStyle}>Langue</dt>
-                <dd className={ddStyle}>
-                  <ul className={ulStyle}>
-                    {offre.langues.map((langue) => (
-                      <li key={langue} className={liStyle}>
-                        {langue}
-                      </li>
-                    ))}
-                  </ul>
-                </dd>
-              </>
-            )}
+              {offre.competencesProfessionnelles.length > 0 && (
+                <>
+                  <dt className={dtStyle}>Savoir être professionnel</dt>
+                  <dd className={ddStyle}>
+                    <ul className={ulStyle}>
+                      {offre.competencesProfessionnelles.map(
+                        (competencePro) => (
+                          <li key={competencePro} className={liStyle}>
+                            {competencePro}
+                          </li>
+                        )
+                      )}
+                    </ul>
+                  </dd>
+                </>
+              )}
 
-            {offre.permis.length > 0 && (
-              <>
-                <dt className={dtStyle}>Permis</dt>
-                <dd className={ddStyle}>
-                  <ul className={ulStyle}>
-                    {offre.permis.map((permis) => (
-                      <li key={permis} className={liStyle}>
-                        {permis}
-                      </li>
-                    ))}
-                  </ul>
-                </dd>
-              </>
-            )}
-          </dl>
-        </section>
-      )}
+              {offre.formations.length > 0 && (
+                <>
+                  <dt className={dtStyle}>Formation</dt>
+                  <dd className={ddStyle}>
+                    <ul className={ulStyle}>
+                      {offre.formations.map((formation) => (
+                        <li key={formation} className={liStyle}>
+                          {formation}
+                        </li>
+                      ))}
+                    </ul>
+                  </dd>
+                </>
+              )}
 
-      {hasEntreprise && (
-        <section aria-labelledby='heading-entreprise' className='mt-6'>
-          <h3 id='heading-entreprise' className={sectionTitleStyle}>
-            <SectionTitleDot />
-            <span className='sr-only'>Informations de l&apos;</span>Entreprise
-          </h3>
+              {offre.langues.length > 0 && (
+                <>
+                  <dt className={dtStyle}>Langue</dt>
+                  <dd className={ddStyle}>
+                    <ul className={ulStyle}>
+                      {offre.langues.map((langue) => (
+                        <li key={langue} className={liStyle}>
+                          {langue}
+                        </li>
+                      ))}
+                    </ul>
+                  </dd>
+                </>
+              )}
 
-          <dl>
-            {offre.infoEntreprise!.lien && (
-              <>
-                <dt className='sr-only'>Lien site</dt>
-                <dd className='mt-4 text-base-regular text-primary hover:text-primary_darken'>
-                  <ExternalLink
-                    href={offre.infoEntreprise!.lien}
-                    label="Site de l'entreprise"
-                    onClick={() => onLienExterne('Lien Site entreprise')}
-                  />
-                </dd>
-              </>
-            )}
+              {offre.permis.length > 0 && (
+                <>
+                  <dt className={dtStyle}>Permis</dt>
+                  <dd className={ddStyle}>
+                    <ul className={ulStyle}>
+                      {offre.permis.map((permis) => (
+                        <li key={permis} className={liStyle}>
+                          {permis}
+                        </li>
+                      ))}
+                    </ul>
+                  </dd>
+                </>
+              )}
+            </dl>
+          </section>
+        )}
 
-            {offre.infoEntreprise!.adaptee && (
-              <>
-                <dt className='mt-4'>
-                  <DataTag text='Entreprise adaptée' />
-                </dt>
-                <dd className='sr-only'>OUI</dd>
-              </>
-            )}
+        {hasEntreprise && (
+          <section aria-labelledby='heading-entreprise' className='mt-6'>
+            <h3 id='heading-entreprise' className={sectionTitleStyle}>
+              <SectionTitleDot />
+              <span className='sr-only'>Informations de l&apos;</span>Entreprise
+            </h3>
 
-            {offre.infoEntreprise!.accessibleTH && (
-              <>
-                <dt className='mt-4'>
-                  <DataTag text='Entreprise handi-bienveillante'></DataTag>
-                </dt>
-                <dd className='sr-only'>OUI</dd>
-              </>
-            )}
+            <dl>
+              {offre.infoEntreprise!.lien && (
+                <>
+                  <dt className='sr-only'>Lien site</dt>
+                  <dd className='mt-4 text-base-regular text-primary hover:text-primary_darken'>
+                    <ExternalLink
+                      href={offre.infoEntreprise!.lien}
+                      label="Site de l'entreprise"
+                      onClick={() => onLienExterne('Lien Site entreprise')}
+                    />
+                  </dd>
+                </>
+              )}
 
-            {offre.infoEntreprise!.detail && (
-              <>
-                <dt className={dtStyle}>Détail de l&apos;entreprise</dt>
-                <dd className='mt-4 text-s-regular whitespace-pre-wrap'>
-                  {offre.infoEntreprise!.detail}
-                </dd>
-              </>
-            )}
-          </dl>
-        </section>
-      )}
-    </div>
+              {offre.infoEntreprise!.adaptee && (
+                <>
+                  <dt className='mt-4'>
+                    <DataTag text='Entreprise adaptée' />
+                  </dt>
+                  <dd className='sr-only'>OUI</dd>
+                </>
+              )}
+
+              {offre.infoEntreprise!.accessibleTH && (
+                <>
+                  <dt className='mt-4'>
+                    <DataTag text='Entreprise handi-bienveillante'></DataTag>
+                  </dt>
+                  <dd className='sr-only'>OUI</dd>
+                </>
+              )}
+
+              {offre.infoEntreprise!.detail && (
+                <>
+                  <dt className={dtStyle}>Détail de l&apos;entreprise</dt>
+                  <dd className='mt-4 text-s-regular whitespace-pre-wrap'>
+                    {offre.infoEntreprise!.detail}
+                  </dd>
+                </>
+              )}
+            </dl>
+          </section>
+        )}
+      </div>
+    </>
   )
 }
 

--- a/components/offres/ServiceCiviqueDetail.tsx
+++ b/components/offres/ServiceCiviqueDetail.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import LienPartageOffre from 'components/offres/LienPartageOffre'
+import PageActionsPortal from 'components/PageActionsPortal'
 import { ButtonStyle } from 'components/ui/Button/Button'
 import IconComponent, { IconName } from 'components/ui/IconComponent'
 import { DataTag } from 'components/ui/Indicateurs/DataTag'
@@ -46,167 +47,170 @@ export default function ServiceCiviqueDetail({
   const pStyle = 'mt-4 text-s-regular pb-4 '
 
   return (
-    <div className='max-w-2xl mx-auto'>
-      <div className='flex justify-between items-center mb-6'>
-        <p className='my-2'>
-          <span className='sr-only'>Domaine : </span>
-          <span className='capitalize'>{offre.domaine}</span>
-        </p>
+    <>
+      <PageActionsPortal>
         <LienPartageOffre
           titreOffre={offre.titre}
           href={`/offres/service-civique/${offre.id}/partage`}
           style={ButtonStyle.PRIMARY}
         />
+      </PageActionsPortal>
+
+      <div className='max-w-2xl mx-auto'>
+        <p className='mb-2'>
+          <span className='sr-only'>Domaine : </span>
+          <span className='capitalize'>{offre.domaine}</span>
+        </p>
+
+        <h2 className='text-l-bold text-primary'>{offre.titre}</h2>
+
+        {hasInfo && (
+          <section aria-labelledby='heading-info' className='mt-6'>
+            <h3 id='heading-info' className='sr-only'>
+              Informations du service civique
+            </h3>
+
+            <dl>
+              {offre.organisation && (
+                <>
+                  <dt className='sr-only'>Organisation</dt>
+                  <dd>{offre.organisation}</dd>
+                </>
+              )}
+
+              {(offre.codeDepartement || offre.ville) && (
+                <>
+                  <dt className='sr-only'>Localisation</dt>
+                  <dd className='mt-6'>
+                    <DataTag
+                      text={`${offre.codeDepartement} - ${offre.ville}`}
+                      iconName={IconName.Location}
+                    />
+                  </dd>
+                </>
+              )}
+
+              {offre.dateDeDebut && (
+                <>
+                  <dt className='sr-only'>Date de début</dt>
+                  <dd className='mt-2'>
+                    <DataTag
+                      text={'Commence le ' + dateDeDebutFormate}
+                      iconName={IconName.Calendar}
+                    />
+                  </dd>
+                </>
+              )}
+
+              {offre.dateDeFin && (
+                <>
+                  <dt className='sr-only'>Date de fin</dt>
+                  <dd className='mt-2'>
+                    <DataTag
+                      text={'Termine le ' + dateDeFinFormate}
+                      iconName={IconName.Calendar}
+                    />
+                  </dd>
+                </>
+              )}
+            </dl>
+          </section>
+        )}
+
+        {hasDescription && (
+          <section aria-labelledby='heading-mission' className='mt-6'>
+            <h3 id='heading-mission' className={sectionTitleStyle}>
+              <SectionTitleDot />
+              Mission
+            </h3>
+
+            <dl>
+              {hasAdresse && (
+                <>
+                  <dt className='sr-only'>Adresse</dt>
+                  <dd className={pStyle}>
+                    {offre.adresseMission}, {offre.codePostal} {offre.ville}
+                  </dd>
+                </>
+              )}
+
+              {offre.description && (
+                <>
+                  <dt className='sr-only'>Description</dt>
+                  <dd className={`${pStyle} whitespace-pre-wrap`}>
+                    {offre.description}
+                  </dd>
+                </>
+              )}
+
+              {offre.lienAnnonce && (
+                <>
+                  <dt className='sr-only'>Lien offre</dt>
+                  <dd
+                    className={`${pStyle} text-primary hover:text-primary_darken`}
+                  >
+                    <ExternalLink
+                      href={offre.lienAnnonce}
+                      label='Voir l’offre détaillée'
+                      onClick={() => onLienExterne('Lien Offre externe')}
+                    />
+                  </dd>
+                </>
+              )}
+            </dl>
+          </section>
+        )}
+
+        {hasOrganisation && (
+          <section aria-labelledby='heading-organisation' className='mt-10'>
+            <h3 id='heading-organisation' className={sectionTitleStyle}>
+              <SectionTitleDot />
+              Organisation
+            </h3>
+
+            <dl>
+              {offre.organisation && (
+                <>
+                  <dt className='sr-only'>Nom</dt>
+                  <dd className={pStyle}>{offre.organisation}</dd>
+                </>
+              )}
+
+              {offre.urlOrganisation && (
+                <>
+                  <dt className='sr-only'>Lien organisation</dt>
+                  <dd
+                    className={`${pStyle} text-primary hover:text-primary_darken`}
+                  >
+                    <ExternalLink
+                      href={offre.urlOrganisation}
+                      label='Site de l’entreprise'
+                      onClick={() => onLienExterne('Lien Site entreprise')}
+                    />
+                  </dd>
+                </>
+              )}
+
+              {offre.adresseOrganisation && (
+                <>
+                  <dt className='sr-only'>Adresse</dt>
+                  <dd className={pStyle}>{offre.adresseOrganisation}</dd>
+                </>
+              )}
+
+              {offre.descriptionOrganisation && (
+                <>
+                  <dt className='sr-only'>Description</dt>
+                  <dd className={`${pStyle} whitespace-pre-wrap`}>
+                    {offre.descriptionOrganisation}
+                  </dd>
+                </>
+              )}
+            </dl>
+          </section>
+        )}
       </div>
-
-      <h2 className='text-l-bold text-primary'>{offre.titre}</h2>
-
-      {hasInfo && (
-        <section aria-labelledby='heading-info' className='mt-6'>
-          <h3 id='heading-info' className='sr-only'>
-            Informations du service civique
-          </h3>
-
-          <dl>
-            {offre.organisation && (
-              <>
-                <dt className='sr-only'>Organisation</dt>
-                <dd>{offre.organisation}</dd>
-              </>
-            )}
-
-            {(offre.codeDepartement || offre.ville) && (
-              <>
-                <dt className='sr-only'>Localisation</dt>
-                <dd className='mt-6'>
-                  <DataTag
-                    text={`${offre.codeDepartement} - ${offre.ville}`}
-                    iconName={IconName.Location}
-                  />
-                </dd>
-              </>
-            )}
-
-            {offre.dateDeDebut && (
-              <>
-                <dt className='sr-only'>Date de début</dt>
-                <dd className='mt-2'>
-                  <DataTag
-                    text={'Commence le ' + dateDeDebutFormate}
-                    iconName={IconName.Calendar}
-                  />
-                </dd>
-              </>
-            )}
-
-            {offre.dateDeFin && (
-              <>
-                <dt className='sr-only'>Date de fin</dt>
-                <dd className='mt-2'>
-                  <DataTag
-                    text={'Termine le ' + dateDeFinFormate}
-                    iconName={IconName.Calendar}
-                  />
-                </dd>
-              </>
-            )}
-          </dl>
-        </section>
-      )}
-
-      {hasDescription && (
-        <section aria-labelledby='heading-mission' className='mt-6'>
-          <h3 id='heading-mission' className={sectionTitleStyle}>
-            <SectionTitleDot />
-            Mission
-          </h3>
-
-          <dl>
-            {hasAdresse && (
-              <>
-                <dt className='sr-only'>Adresse</dt>
-                <dd className={pStyle}>
-                  {offre.adresseMission}, {offre.codePostal} {offre.ville}
-                </dd>
-              </>
-            )}
-
-            {offre.description && (
-              <>
-                <dt className='sr-only'>Description</dt>
-                <dd className={`${pStyle} whitespace-pre-wrap`}>
-                  {offre.description}
-                </dd>
-              </>
-            )}
-
-            {offre.lienAnnonce && (
-              <>
-                <dt className='sr-only'>Lien offre</dt>
-                <dd
-                  className={`${pStyle} text-primary hover:text-primary_darken`}
-                >
-                  <ExternalLink
-                    href={offre.lienAnnonce}
-                    label='Voir l’offre détaillée'
-                    onClick={() => onLienExterne('Lien Offre externe')}
-                  />
-                </dd>
-              </>
-            )}
-          </dl>
-        </section>
-      )}
-
-      {hasOrganisation && (
-        <section aria-labelledby='heading-organisation' className='mt-10'>
-          <h3 id='heading-organisation' className={sectionTitleStyle}>
-            <SectionTitleDot />
-            Organisation
-          </h3>
-
-          <dl>
-            {offre.organisation && (
-              <>
-                <dt className='sr-only'>Nom</dt>
-                <dd className={pStyle}>{offre.organisation}</dd>
-              </>
-            )}
-
-            {offre.urlOrganisation && (
-              <>
-                <dt className='sr-only'>Lien organisation</dt>
-                <dd
-                  className={`${pStyle} text-primary hover:text-primary_darken`}
-                >
-                  <ExternalLink
-                    href={offre.urlOrganisation}
-                    label='Site de l’entreprise'
-                    onClick={() => onLienExterne('Lien Site entreprise')}
-                  />
-                </dd>
-              </>
-            )}
-
-            {offre.adresseOrganisation && (
-              <>
-                <dt className='sr-only'>Adresse</dt>
-                <dd className={pStyle}>{offre.adresseOrganisation}</dd>
-              </>
-            )}
-
-            {offre.descriptionOrganisation && (
-              <>
-                <dt className='sr-only'>Description</dt>
-                <dd className={`${pStyle} whitespace-pre-wrap`}>
-                  {offre.descriptionOrganisation}
-                </dd>
-              </>
-            )}
-          </dl>
-        </section>
-      )}
-    </div>
+    </>
   )
 }
 

--- a/pages/mes-jeunes/[jeune_id].tsx
+++ b/pages/mes-jeunes/[jeune_id].tsx
@@ -11,8 +11,9 @@ import DeleteJeuneActifModal from 'components/jeune/DeleteJeuneActifModal'
 import DeleteJeuneInactifModal from 'components/jeune/DeleteJeuneInactifModal'
 import { DetailsJeune } from 'components/jeune/DetailsJeune'
 import { ResumeIndicateursJeune } from 'components/jeune/ResumeIndicateursJeune'
+import PageActionsPortal from 'components/PageActionsPortal'
 import { OngletRdvsBeneficiaire } from 'components/rdv/OngletRdvsBeneficiaire'
-import { ButtonStyle } from 'components/ui/Button/Button'
+import Button, { ButtonStyle } from 'components/ui/Button/Button'
 import ButtonLink from 'components/ui/Button/ButtonLink'
 import IconComponent, { IconName } from 'components/ui/IconComponent'
 import Tab from 'components/ui/Navigation/Tab'
@@ -266,27 +267,22 @@ function FicheJeune({
 
   return (
     <>
+      <PageActionsPortal>
+        <Button onClick={openDeleteJeuneModal} style={ButtonStyle.SECONDARY}>
+          <IconComponent
+            name={IconName.Trashcan}
+            focusable={false}
+            aria-hidden={true}
+            className='mr-2 w-4 h-4'
+          />
+          Supprimer ce compte
+        </Button>
+      </PageActionsPortal>
+
       {showSuppressionCompteBeneficiaireError && (
         <FailureAlert
           label='Suite à un problème inconnu la suppression a échoué. Vous pouvez réessayer.'
           onAcknowledge={() => setShowSuppressionCompteBeneficiaireError(false)}
-        />
-      )}
-
-      {showModaleDeleteJeuneActif && (
-        <DeleteJeuneActifModal
-          jeune={jeune}
-          onClose={() => setShowModaleDeleteJeuneActif(false)}
-          motifsSuppression={motifsSuppression}
-          soumettreSuppression={archiverJeuneActif}
-        />
-      )}
-
-      {showModaleDeleteJeuneInactif && (
-        <DeleteJeuneInactifModal
-          jeune={jeune}
-          onClose={() => setShowModaleDeleteJeuneInactif(false)}
-          onDelete={supprimerJeuneInactif}
         />
       )}
 
@@ -320,7 +316,6 @@ function FicheJeune({
           jeune={jeune}
           structureConseiller={conseiller?.structure}
           onDossierMiloClick={trackDossierMiloClick}
-          onDeleteJeuneClick={openDeleteJeuneModal}
         />
       </div>
 
@@ -479,6 +474,23 @@ function FicheJeune({
             metadonneesFavoris={metadonneesFavoris!}
           />
         </div>
+      )}
+
+      {showModaleDeleteJeuneActif && (
+        <DeleteJeuneActifModal
+          jeune={jeune}
+          onClose={() => setShowModaleDeleteJeuneActif(false)}
+          motifsSuppression={motifsSuppression}
+          soumettreSuppression={archiverJeuneActif}
+        />
+      )}
+
+      {showModaleDeleteJeuneInactif && (
+        <DeleteJeuneInactifModal
+          jeune={jeune}
+          onClose={() => setShowModaleDeleteJeuneInactif(false)}
+          onDelete={supprimerJeuneInactif}
+        />
       )}
     </>
   )

--- a/pages/mes-jeunes/[jeune_id]/actions/[action_id].tsx
+++ b/pages/mes-jeunes/[jeune_id]/actions/[action_id].tsx
@@ -8,6 +8,7 @@ import { CommentairesAction } from 'components/action/CommentairesAction'
 import { HistoriqueAction } from 'components/action/HistoriqueAction'
 import StatutActionForm from 'components/action/StatutActionForm'
 import TagQualificationAction from 'components/action/TagQualificationAction'
+import PageActionsPortal from 'components/PageActionsPortal'
 import Button, { ButtonStyle } from 'components/ui/Button/Button'
 import IconComponent, { IconName } from 'components/ui/IconComponent'
 import FailureAlert from 'components/ui/Notifications/FailureAlert'
@@ -143,6 +144,27 @@ function PageAction({ action, jeune, commentaires }: PageActionProps) {
 
   return (
     <>
+      <PageActionsPortal>
+        <>
+          {afficherSuppressionAction && (
+            <Button
+              label="Supprimer l'action"
+              onClick={() => deleteAction()}
+              style={ButtonStyle.SECONDARY}
+              disabled={deleteDisabled}
+            >
+              <IconComponent
+                name={IconName.Trashcan}
+                aria-hidden={true}
+                focusable={false}
+                className='w-4 h-4 mr-2'
+              />
+              Supprimer
+            </Button>
+          )}
+        </>
+      </PageActionsPortal>
+
       {showEchecMessage && (
         <FailureAlert
           label="Une erreur s'est produite, veuillez réessayer ultérieurement"
@@ -154,28 +176,12 @@ function PageAction({ action, jeune, commentaires }: PageActionProps) {
         <TagQualificationAction statut={statut} qualification={qualification} />
       )}
 
-      <div className='flex items-start justify-between mb-5'>
-        <h2 className='text-m-bold text-grey_800' title='Intitulé de l’action'>
-          {action.content}
-        </h2>
-
-        {afficherSuppressionAction && (
-          <Button
-            label="Supprimer l'action"
-            onClick={() => deleteAction()}
-            style={ButtonStyle.SECONDARY}
-            disabled={deleteDisabled}
-          >
-            <IconComponent
-              name={IconName.Trashcan}
-              aria-hidden={true}
-              focusable={false}
-              className='w-4 h-4 mr-2'
-            />
-            Supprimer
-          </Button>
-        )}
-      </div>
+      <h2
+        className='text-m-bold text-grey_800 mb-5'
+        title='Intitulé de l’action'
+      >
+        {action.content}
+      </h2>
 
       {action.comment && <p className='mb-8'>{action.comment}</p>}
 

--- a/pages/mes-jeunes/edition-rdv.tsx
+++ b/pages/mes-jeunes/edition-rdv.tsx
@@ -6,6 +6,7 @@ import React, { useState } from 'react'
 
 import ConfirmationUpdateRdvModal from 'components/ConfirmationUpdateRdvModal'
 import LeavePageConfirmationModal from 'components/LeavePageConfirmationModal'
+import PageActionsPortal from 'components/PageActionsPortal'
 import DeleteRdvModal from 'components/rdv/DeleteRdvModal'
 import { EditionRdvForm } from 'components/rdv/EditionRdvForm'
 import Button, { ButtonStyle } from 'components/ui/Button/Button'
@@ -214,6 +215,45 @@ function EditionRdv({
 
   return (
     <>
+      <PageActionsPortal>
+        <>
+          {evenement && !estClos(evenement) && !estCreeParSiMILO(evenement) && (
+            <Button
+              style={ButtonStyle.SECONDARY}
+              onClick={handleDelete}
+              label={`Supprimer l’événement du ${evenement.date}`}
+            >
+              <IconComponent
+                name={IconName.Trashcan}
+                aria-hidden='true'
+                focusable='false'
+                className='mr-2 w-4 h-4'
+              />
+              Supprimer
+            </Button>
+          )}
+
+          {evenement && estAClore(evenement) && (
+            <ButtonLink
+              style={ButtonStyle.PRIMARY}
+              href={`/evenements/${
+                evenement.id
+              }/cloture?redirectUrl=${encodeURIComponent(
+                returnTo + '?onglet=etablissement'
+              )}`}
+            >
+              <IconComponent
+                name={IconName.Clipboard}
+                aria-hidden={true}
+                focusable={false}
+                className='mr-2 w-4 h-4'
+              />
+              Clore
+            </ButtonLink>
+          )}
+        </>
+      </PageActionsPortal>
+
       {showDeleteRdvError && (
         <FailureAlert
           label="Votre événement n'a pas été supprimé, veuillez essayer ultérieurement"
@@ -235,45 +275,6 @@ function EditionRdv({
 
       {evenement && (
         <>
-          <div className='flex'>
-            {!estClos(evenement) && !estCreeParSiMILO(evenement) && (
-              <Button
-                style={ButtonStyle.SECONDARY}
-                onClick={handleDelete}
-                label={`Supprimer l’événement du ${evenement.date}`}
-                className='min-w-fit w-1/4'
-              >
-                <IconComponent
-                  name={IconName.Trashcan}
-                  aria-hidden='true'
-                  focusable='false'
-                  className='mr-2 w-4 h-4'
-                />
-                Supprimer
-              </Button>
-            )}
-
-            {estAClore(evenement) && (
-              <ButtonLink
-                style={ButtonStyle.PRIMARY}
-                href={`/evenements/${
-                  evenement.id
-                }/cloture?redirectUrl=${encodeURIComponent(
-                  returnTo + '?onglet=etablissement'
-                )}`}
-                className='ml-6 min-w-fit w-1/4'
-              >
-                <IconComponent
-                  name={IconName.Clipboard}
-                  aria-hidden={true}
-                  focusable={false}
-                  className='mr-2 w-4 h-4'
-                />
-                Clore
-              </ButtonLink>
-            )}
-          </div>
-
           {estAClore(evenement) && (
             <div className='pt-6'>
               <FailureAlert label='Cet événement est passé et doit être clos' />

--- a/styles/components/Layouts.module.css
+++ b/styles/components/Layouts.module.css
@@ -40,11 +40,6 @@
   display: none;
 }
 
-.header {
-  padding: 32px 48px;
-  border-bottom: 1px solid theme('colors.primary_lighten');
-}
-
 .content {
   flex-grow: 1;
   margin: auto;

--- a/tests/components/DetailsJeune.test.tsx
+++ b/tests/components/DetailsJeune.test.tsx
@@ -33,7 +33,6 @@ describe('<DetailsJeune>', () => {
         jeune={jeune}
         structureConseiller={StructureConseiller.MILO}
         onDossierMiloClick={() => {}}
-        onDeleteJeuneClick={() => {}}
       />,
       { customDependances: { jeunesService } }
     )
@@ -64,7 +63,6 @@ describe('<DetailsJeune>', () => {
         jeune={jeune}
         structureConseiller={StructureConseiller.MILO}
         onDossierMiloClick={() => {}}
-        onDeleteJeuneClick={() => {}}
       />,
       { customDependances: { jeunesService } }
     )
@@ -83,7 +81,6 @@ describe('<DetailsJeune>', () => {
         jeune={jeune}
         structureConseiller={StructureConseiller.MILO}
         onDossierMiloClick={() => {}}
-        onDeleteJeuneClick={() => {}}
       />,
       { customDependances: { jeunesService } }
     )
@@ -106,7 +103,6 @@ describe('<DetailsJeune>', () => {
             jeune={jeune}
             structureConseiller={StructureConseiller.MILO}
             onDossierMiloClick={() => {}}
-            onDeleteJeuneClick={() => {}}
           />,
           { customDependances: { jeunesService } }
         )
@@ -130,7 +126,6 @@ describe('<DetailsJeune>', () => {
               jeune={jeune}
               structureConseiller={StructureConseiller.POLE_EMPLOI}
               onDossierMiloClick={() => {}}
-              onDeleteJeuneClick={() => {}}
             />,
             { customDependances: { jeunesService } }
           )
@@ -158,9 +153,11 @@ describe('<DetailsJeune>', () => {
             jeune={jeune}
             structureConseiller={StructureConseiller.POLE_EMPLOI}
             onDossierMiloClick={() => {}}
-            onDeleteJeuneClick={() => {}}
           />,
-          { customDependances: { jeunesService }, customAlerte: { alerteSetter } }
+          {
+            customDependances: { jeunesService },
+            customAlerte: { alerteSetter },
+          }
         )
       })
 
@@ -237,9 +234,11 @@ describe('<DetailsJeune>', () => {
             jeune={jeune}
             structureConseiller={StructureConseiller.POLE_EMPLOI}
             onDossierMiloClick={() => {}}
-            onDeleteJeuneClick={() => {}}
           />,
-          { customDependances: { jeunesService }, customAlerte: { alerteSetter } }
+          {
+            customDependances: { jeunesService },
+            customAlerte: { alerteSetter },
+          }
         )
       })
 
@@ -317,7 +316,6 @@ describe('<DetailsJeune>', () => {
           jeune={jeune}
           structureConseiller={StructureConseiller.MILO}
           onDossierMiloClick={() => {}}
-          onDeleteJeuneClick={() => {}}
         />,
         { customDependances: { jeunesService } }
       )

--- a/tests/pages/DetailImmersion.page.test.tsx
+++ b/tests/pages/DetailImmersion.page.test.tsx
@@ -14,6 +14,7 @@ import withDependance from 'utils/injectionDependances/withDependance'
 
 jest.mock('utils/auth/withMandatorySessionOrRedirect')
 jest.mock('utils/injectionDependances/withDependance')
+jest.mock('components/PageActionsPortal')
 
 describe('Page Détail Offre Emploi', () => {
   describe('client side', () => {

--- a/tests/pages/DetailOffreEmploi.page.test.tsx
+++ b/tests/pages/DetailOffreEmploi.page.test.tsx
@@ -14,6 +14,7 @@ import withDependance from 'utils/injectionDependances/withDependance'
 
 jest.mock('utils/auth/withMandatorySessionOrRedirect')
 jest.mock('utils/injectionDependances/withDependance')
+jest.mock('components/PageActionsPortal')
 
 describe('Page Détail Offre Emploi', () => {
   describe('client side', () => {

--- a/tests/pages/DetailServiceCivique.test.tsx
+++ b/tests/pages/DetailServiceCivique.test.tsx
@@ -14,6 +14,7 @@ import withDependance from 'utils/injectionDependances/withDependance'
 
 jest.mock('utils/auth/withMandatorySessionOrRedirect')
 jest.mock('utils/injectionDependances/withDependance')
+jest.mock('components/PageActionsPortal')
 
 describe('Page Détail Service civique', () => {
   describe('client side', () => {

--- a/tests/pages/edition-rdv/EditionAnimationCollective.page.test.tsx
+++ b/tests/pages/edition-rdv/EditionAnimationCollective.page.test.tsx
@@ -1,39 +1,31 @@
 import { act, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { DateTime } from 'luxon'
 import { useRouter } from 'next/router'
 import { GetServerSidePropsContext } from 'next/types'
 
 import {
   typesEvenement,
   typesRdvAnimationsCollectives,
-  typesRdvCEJ,
   uneAnimationCollective,
   unEvenement,
 } from 'fixtures/evenement'
 import { desItemsJeunes, uneBaseJeune } from 'fixtures/jeune'
 import { mockedEvenementsService, mockedJeunesService } from 'fixtures/services'
 import { StructureConseiller } from 'interfaces/conseiller'
-import {
-  Evenement,
-  StatutAnimationCollective,
-  TypeEvenement,
-} from 'interfaces/evenement'
+import { StatutAnimationCollective, TypeEvenement } from 'interfaces/evenement'
 import { BaseJeune, getNomJeuneComplet, JeuneFromListe } from 'interfaces/jeune'
 import EditionRdv, { getServerSideProps } from 'pages/mes-jeunes/edition-rdv'
 import { AlerteParam } from 'referentiel/alerteParam'
-import { modalites } from 'referentiel/evenement'
 import { EvenementsService } from 'services/evenements.service'
 import { JeunesService } from 'services/jeunes.service'
-import getByDescriptionTerm, { getByTextContent } from 'tests/querySelector'
 import renderWithContexts from 'tests/renderWithContexts'
 import { withMandatorySessionOrRedirect } from 'utils/auth/withMandatorySessionOrRedirect'
-import { DATETIME_LONG, toFrenchFormat } from 'utils/date'
 import withDependance from 'utils/injectionDependances/withDependance'
 
 jest.mock('utils/auth/withMandatorySessionOrRedirect')
 jest.mock('utils/injectionDependances/withDependance')
 jest.mock('components/Modal')
+jest.mock('components/PageActionsPortal')
 
 describe('EditionAnimationCollective', () => {
   describe('server side', () => {

--- a/tests/pages/edition-rdv/EditionRdv.page.test.tsx
+++ b/tests/pages/edition-rdv/EditionRdv.page.test.tsx
@@ -24,6 +24,7 @@ import withDependance from 'utils/injectionDependances/withDependance'
 jest.mock('utils/auth/withMandatorySessionOrRedirect')
 jest.mock('utils/injectionDependances/withDependance')
 jest.mock('components/Modal')
+jest.mock('components/PageActionsPortal')
 
 describe('EditionRdv', () => {
   describe('server side', () => {

--- a/tests/pages/fiche-jeune/GestionCompte.test.tsx
+++ b/tests/pages/fiche-jeune/GestionCompte.test.tsx
@@ -17,6 +17,7 @@ import { JeunesService } from 'services/jeunes.service'
 import renderWithContexts from 'tests/renderWithContexts'
 
 jest.mock('components/Modal')
+jest.mock('components/PageActionsPortal')
 
 describe('Gestion du compte dans la fiche jeune', () => {
   let motifsSuppression: MotifSuppressionJeune[]


### PR DESCRIPTION
**Objectif** : permettre de mettre des boutons dans le header des pages

**Problème** : 
- on a voulu mutualiser le header des pages car il porte du comportement commun (fil d'ariane, titre)
- le header est un composant appelé dans le Layout qui se base sur URL + props de la page pour afficher le fil d'ariane et le titre
- pas possible/trop lourd d'utiliser le même comportement pour des boutons (il faudrait des props pour les labels, pour les onClick...)

**Solution** : On utilise le même principe que la `Modal`
- un emplacement dédié dans le header (`<div id='page-actions-root'/>`)
- un composant `PageActionsPortal` qui va créer un _portal_ pour se positionner dans l'emplacement dédie
- chaque page qui le nécessite injecte dans une instance de `PageActionsPortal` les boutons dont elle a besoin