### PR TITLE
Force conseiller & prevent API calls

### DIFF
--- a/components/ActualitesMenuButton.tsx
+++ b/components/ActualitesMenuButton.tsx
@@ -1,20 +1,17 @@
 import React from 'react'
 
-import { StructureConseiller } from '../interfaces/conseiller'
-
-import IconComponent, { IconName } from './ui/IconComponent'
-
+import IconComponent, { IconName } from 'components/ui/IconComponent'
+import { Conseiller, estPoleEmploi } from 'interfaces/conseiller'
 import { LeanBe } from 'utils/hooks/useLeanBeWidget'
 
 interface ActualitesMenuButtonProps {
-  structure: StructureConseiller | undefined
+  conseiller: Conseiller
 }
 
-function ActualitesMenuButton({ structure }: ActualitesMenuButtonProps) {
-  const widgetId =
-    structure === StructureConseiller.POLE_EMPLOI
-      ? LeanBe.PE_WIDGET_ID
-      : LeanBe.MILO_WIDGET_ID
+function ActualitesMenuButton({ conseiller }: ActualitesMenuButtonProps) {
+  const widgetId = estPoleEmploi(conseiller)
+    ? LeanBe.PE_WIDGET_ID
+    : LeanBe.MILO_WIDGET_ID
   const classWidget = `SGBF-open-${widgetId} w-full`
   const classMenu =
     'flex p-2 mb-6 items-center layout_base:justify-center rounded-l layout_s:justify-start layout_l:justify-start hover:bg-primary_darken'

--- a/components/EncartAgenceRequise.tsx
+++ b/components/EncartAgenceRequise.tsx
@@ -3,32 +3,29 @@ import React, { useState } from 'react'
 import RenseignementAgenceModal from 'components/RenseignementAgenceModal'
 import Button, { ButtonStyle } from 'components/ui/Button/Button'
 import IconComponent, { IconName } from 'components/ui/IconComponent'
-import { StructureConseiller } from 'interfaces/conseiller'
+import { Conseiller, estMilo, StructureConseiller } from 'interfaces/conseiller'
 import { Agence } from 'interfaces/referentiel'
 import { trackEvent } from 'utils/analytics/matomo'
 
 type EncartAgenceRequiseProps = {
-  structureConseiller: StructureConseiller
+  conseiller: Conseiller
   getAgences: (structure: StructureConseiller) => Promise<Agence[]>
   onAgenceChoisie: (agence: { id?: string; nom: string }) => Promise<void>
   onChangeAffichageModal: (trackingMessage: string) => void
 }
 export default function EncartAgenceRequise({
-  structureConseiller,
+  conseiller,
   getAgences,
   onAgenceChoisie,
   onChangeAffichageModal,
 }: EncartAgenceRequiseProps): JSX.Element {
   const [agences, setAgences] = useState<Agence[]>([])
   const [showAgenceModal, setShowAgenceModal] = useState<boolean>(false)
-  const labelEtablissement =
-    structureConseiller === StructureConseiller.MILO
-      ? 'Mission Locale'
-      : 'agence'
+  const labelEtablissement = estMilo(conseiller) ? 'Mission Locale' : 'agence'
 
   async function openAgenceModal() {
     if (!agences.length) {
-      setAgences(await getAgences(structureConseiller))
+      setAgences(await getAgences(conseiller.structure))
     }
     setShowAgenceModal(true)
     onChangeAffichageModal('Pop-in sélection agence')
@@ -49,7 +46,7 @@ export default function EncartAgenceRequise({
 
   function trackContacterSupport() {
     trackEvent({
-      structure: structureConseiller,
+      structure: conseiller.structure,
       categorie: 'Contact Support',
       action: 'Pop-in sélection agence',
       nom: '',
@@ -84,7 +81,7 @@ export default function EncartAgenceRequise({
 
       {showAgenceModal && agences.length > 0 && (
         <RenseignementAgenceModal
-          structureConseiller={structureConseiller}
+          conseiller={conseiller}
           referentielAgences={agences}
           onAgenceChoisie={renseignerAgence}
           onContacterSupport={trackContacterSupport}

--- a/components/NavLinks.tsx
+++ b/components/NavLinks.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import ActualitesMenuButton from 'components/ActualitesMenuButton'
 import NavLink from 'components/ui/Form/NavLink'
 import { IconName } from 'components/ui/IconComponent'
-import { StructureConseiller } from 'interfaces/conseiller'
+import { estSuperviseur, estMilo, estPoleEmploi } from 'interfaces/conseiller'
 import { trackEvent } from 'utils/analytics/matomo'
 import { useConseiller } from 'utils/conseiller/conseillerContext'
 import { useLeanBeWidget } from 'utils/hooks/useLeanBeWidget'
@@ -30,22 +30,18 @@ export default function NavLinks({
   const router = useRouter()
   const [conseiller] = useConseiller()
 
-  const isMilo = conseiller?.structure === StructureConseiller.MILO
-  const isPoleEmploi = conseiller?.structure === StructureConseiller.POLE_EMPLOI
-  const isSuperviseur = conseiller?.estSuperviseur
-
   const isCurrentRoute = (href: string) => router.pathname.startsWith(href)
 
   async function trackLogout() {
     trackEvent({
-      structure: conseiller!.structure,
+      structure: conseiller.structure,
       categorie: 'Session',
       action: 'Déconnexion',
       nom: '',
     })
   }
 
-  useLeanBeWidget(conseiller?.structure)
+  useLeanBeWidget(conseiller.structure)
 
   return (
     <>
@@ -60,7 +56,7 @@ export default function NavLinks({
           />
         )}
 
-        {!isPoleEmploi && items.includes(NavItem.Rdvs) && (
+        {!estPoleEmploi(conseiller) && items.includes(NavItem.Rdvs) && (
           <NavLink
             isActive={isCurrentRoute('/agenda')}
             href='/agenda'
@@ -82,7 +78,7 @@ export default function NavLinks({
           />
         )}
 
-        {!isPoleEmploi && items.includes(NavItem.Pilotage) && (
+        {!estPoleEmploi(conseiller) && items.includes(NavItem.Pilotage) && (
           <>
             <NavLink
               iconName={IconName.Board}
@@ -94,62 +90,55 @@ export default function NavLinks({
           </>
         )}
 
-        {!isPoleEmploi && items.includes(NavItem.Etablissement) && (
-          <>
+        {!estPoleEmploi(conseiller) &&
+          items.includes(NavItem.Etablissement) && (
             <NavLink
               iconName={IconName.RoundedArrowRight}
-              label={isMilo ? 'Mission Locale' : 'Agence'}
+              label={estMilo(conseiller) ? 'Mission Locale' : 'Agence'}
               href='/etablissement'
               isActive={isCurrentRoute('/mission-locale')}
               showLabelOnSmallScreen={showLabelsOnSmallScreen}
             />
-          </>
-        )}
+          )}
 
-        {isSuperviseur && items.includes(NavItem.Supervision) && (
-          <>
-            <NavLink
-              iconName={IconName.ArrowRight}
-              label='Réaffectation'
-              href='/reaffectation'
-              isActive={isCurrentRoute('/reaffectation')}
-              showLabelOnSmallScreen={showLabelsOnSmallScreen}
-            />
-          </>
+        {estSuperviseur(conseiller) && items.includes(NavItem.Supervision) && (
+          <NavLink
+            iconName={IconName.ArrowRight}
+            label='Réaffectation'
+            href='/reaffectation'
+            isActive={isCurrentRoute('/reaffectation')}
+            showLabelOnSmallScreen={showLabelsOnSmallScreen}
+          />
         )}
 
         {items.includes(NavItem.Messagerie) && (
-          <>
-            <NavLink
-              iconName={IconName.Note}
-              label='Messagerie'
-              href='/mes-jeunes'
-              isActive={isCurrentRoute('/mes-jeunes')}
-              showLabelOnSmallScreen={showLabelsOnSmallScreen}
-            />
-          </>
+          <NavLink
+            iconName={IconName.Note}
+            label='Messagerie'
+            href='/mes-jeunes'
+            isActive={isCurrentRoute('/mes-jeunes')}
+            showLabelOnSmallScreen={showLabelsOnSmallScreen}
+          />
         )}
 
         {items.includes(NavItem.Raccourci) && (
-          <>
-            <NavLink
-              iconName={IconName.Add}
-              label='Créer un raccourci'
-              href='/raccourci'
-              isActive={isCurrentRoute('/raccourci')}
-              showLabelOnSmallScreen={showLabelsOnSmallScreen}
-            />
-          </>
+          <NavLink
+            iconName={IconName.Add}
+            label='Créer un raccourci'
+            href='/raccourci'
+            isActive={isCurrentRoute('/raccourci')}
+            showLabelOnSmallScreen={showLabelsOnSmallScreen}
+          />
         )}
 
         {items.includes(NavItem.Actualites) && (
-          <ActualitesMenuButton structure={conseiller?.structure} />
+          <ActualitesMenuButton structure={conseiller.structure} />
         )}
 
         {items.includes(NavItem.Aide) && (
           <NavLink
             href={
-              isMilo
+              estMilo(conseiller)
                 ? process.env.FAQ_MILO_EXTERNAL_LINK ?? ''
                 : process.env.FAQ_PE_EXTERNAL_LINK ?? ''
             }
@@ -161,7 +150,7 @@ export default function NavLinks({
         )}
       </div>
       <div className='flex flex-col'>
-        {conseiller && items.includes(NavItem.Profil) && (
+        {items.includes(NavItem.Profil) && (
           <NavLink
             isActive={isCurrentRoute('/profil')}
             href='/profil'

--- a/components/NavLinks.tsx
+++ b/components/NavLinks.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import ActualitesMenuButton from 'components/ActualitesMenuButton'
 import NavLink from 'components/ui/Form/NavLink'
 import { IconName } from 'components/ui/IconComponent'
-import { estSuperviseur, estMilo, estPoleEmploi } from 'interfaces/conseiller'
+import { estMilo, estPoleEmploi, estSuperviseur } from 'interfaces/conseiller'
 import { trackEvent } from 'utils/analytics/matomo'
 import { useConseiller } from 'utils/conseiller/conseillerContext'
 import { useLeanBeWidget } from 'utils/hooks/useLeanBeWidget'
@@ -41,7 +41,7 @@ export default function NavLinks({
     })
   }
 
-  useLeanBeWidget(conseiller.structure)
+  useLeanBeWidget(conseiller)
 
   return (
     <>
@@ -132,7 +132,7 @@ export default function NavLinks({
         )}
 
         {items.includes(NavItem.Actualites) && (
-          <ActualitesMenuButton structure={conseiller.structure} />
+          <ActualitesMenuButton conseiller={conseiller} />
         )}
 
         {items.includes(NavItem.Aide) && (

--- a/components/RenseignementAgenceModal.tsx
+++ b/components/RenseignementAgenceModal.tsx
@@ -7,11 +7,11 @@ import {
   RenseignementAgenceMissionLocaleForm,
 } from 'components/RenseignementAgenceMissionLocaleForm'
 import InformationMessage from 'components/ui/Notifications/InformationMessage'
-import { StructureConseiller } from 'interfaces/conseiller'
+import { Conseiller, estMilo } from 'interfaces/conseiller'
 import { Agence } from 'interfaces/referentiel'
 
 interface RenseignementAgenceModalProps {
-  structureConseiller: string
+  conseiller: Conseiller
   referentielAgences: Agence[]
   onAgenceChoisie: (agence: { id?: string; nom: string }) => void
   onContacterSupport: () => void
@@ -19,23 +19,21 @@ interface RenseignementAgenceModalProps {
 }
 
 export default function RenseignementAgenceModal({
-  structureConseiller,
+  conseiller,
   referentielAgences,
   onAgenceChoisie,
   onContacterSupport,
   onClose,
 }: RenseignementAgenceModalProps) {
-  const labelAgence =
-    structureConseiller === StructureConseiller.MILO
-      ? 'Mission Locale'
-      : 'agence'
+  const conseillerEstMilo = estMilo(conseiller)
+  const labelAgence = conseillerEstMilo ? 'Mission Locale' : 'agence'
 
   return (
     <Modal
       title={`Ajoutez votre ${labelAgence} à votre profil`}
       onClose={onClose}
     >
-      {structureConseiller !== StructureConseiller.MILO && (
+      {!conseillerEstMilo && (
         <InformationMessage label='La liste des agences a été mise à jour et les accents sont pris en compte.' />
       )}
 
@@ -45,7 +43,7 @@ export default function RenseignementAgenceModal({
         />
       </div>
 
-      {structureConseiller === StructureConseiller.MILO && (
+      {conseillerEstMilo && (
         <RenseignementAgenceMissionLocaleForm
           referentielAgences={referentielAgences}
           onAgenceChoisie={onAgenceChoisie}
@@ -55,7 +53,7 @@ export default function RenseignementAgenceModal({
         />
       )}
 
-      {structureConseiller !== StructureConseiller.MILO && (
+      {!conseillerEstMilo && (
         <RenseignementAgenceForm
           referentielAgences={referentielAgences}
           onAgenceChoisie={onAgenceChoisie}

--- a/components/action/CommentairesAction.tsx
+++ b/components/action/CommentairesAction.tsx
@@ -59,7 +59,7 @@ export function CommentairesAction({
               <CommentaireAction
                 key={commentaire.id}
                 commentaire={commentaire}
-                idConseiller={conseiller?.id}
+                idConseiller={conseiller.id}
               />
             ))}
           </dl>

--- a/components/action/OngletActions.tsx
+++ b/components/action/OngletActions.tsx
@@ -8,7 +8,7 @@ import {
   EtatQualificationAction,
   StatutAction,
 } from 'interfaces/action'
-import { Conseiller, isMilo, isPoleEmploi } from 'interfaces/conseiller'
+import { Conseiller, estMilo, estPoleEmploi } from 'interfaces/conseiller'
 import { BaseJeune } from 'interfaces/jeune'
 import { MetadonneesPagination } from 'types/pagination'
 
@@ -116,11 +116,11 @@ export function OngletActions({
 
   return (
     <>
-      {isPoleEmploi(conseiller) && (
+      {estPoleEmploi(conseiller) && (
         <IntegrationPoleEmploi label='actions et démarches' />
       )}
 
-      {!isPoleEmploi(conseiller) && (
+      {!estPoleEmploi(conseiller) && (
         <>
           {actionsInitiales.metadonnees.nombreTotal === 0 && (
             <p className='text-base-bold mb-2'>
@@ -131,7 +131,7 @@ export function OngletActions({
           {actionsInitiales.metadonnees.nombreTotal > 0 && (
             <>
               <TableauActionsJeune
-                afficherFiltresEtatsQualification={isMilo(conseiller)}
+                afficherFiltresEtatsQualification={estMilo(conseiller)}
                 jeune={jeune}
                 actions={actionsAffichees}
                 isLoading={isLoading}

--- a/components/action/OngletActions.tsx
+++ b/components/action/OngletActions.tsx
@@ -8,12 +8,12 @@ import {
   EtatQualificationAction,
   StatutAction,
 } from 'interfaces/action'
+import { Conseiller, isMilo, isPoleEmploi } from 'interfaces/conseiller'
 import { BaseJeune } from 'interfaces/jeune'
 import { MetadonneesPagination } from 'types/pagination'
 
 interface OngletActionsProps {
-  afficherActions: boolean
-  afficherFiltresEtatsQualification: boolean
+  conseiller: Conseiller
   jeune: BaseJeune
   actionsInitiales: {
     actions: Action[]
@@ -39,8 +39,7 @@ export function OngletActions({
   actionsInitiales,
   getActions,
   jeune,
-  afficherActions,
-  afficherFiltresEtatsQualification,
+  conseiller,
 }: OngletActionsProps) {
   const [actionsAffichees, setActionsAffichees] = useState<Action[]>(
     actionsInitiales.actions
@@ -117,38 +116,40 @@ export function OngletActions({
 
   return (
     <>
-      {!afficherActions && (
+      {isPoleEmploi(conseiller) && (
         <IntegrationPoleEmploi label='actions et démarches' />
       )}
 
-      {afficherActions && actionsInitiales.metadonnees.nombreTotal === 0 && (
-        <p className='text-base-bold mb-2'>
-          {jeune.prenom} {jeune.nom} n’a pas encore d’action
-        </p>
-      )}
-
-      {afficherActions && actionsInitiales.metadonnees.nombreTotal > 0 && (
+      {!isPoleEmploi(conseiller) && (
         <>
-          <TableauActionsJeune
-            afficherFiltresEtatsQualification={
-              afficherFiltresEtatsQualification
-            }
-            jeune={jeune}
-            actions={actionsAffichees}
-            isLoading={isLoading}
-            onFiltres={filtrerActions}
-            onTri={trierActions}
-            tri={tri}
-          />
-          {nombrePages > 1 && (
-            <div className='mt-6'>
-              <Pagination
-                nomListe='actions'
-                nombreDePages={nombrePages}
-                pageCourante={pageCourante}
-                allerALaPage={changerPage}
+          {actionsInitiales.metadonnees.nombreTotal === 0 && (
+            <p className='text-base-bold mb-2'>
+              {jeune.prenom} {jeune.nom} n’a pas encore d’action
+            </p>
+          )}
+
+          {actionsInitiales.metadonnees.nombreTotal > 0 && (
+            <>
+              <TableauActionsJeune
+                afficherFiltresEtatsQualification={isMilo(conseiller)}
+                jeune={jeune}
+                actions={actionsAffichees}
+                isLoading={isLoading}
+                onFiltres={filtrerActions}
+                onTri={trierActions}
+                tri={tri}
               />
-            </div>
+              {nombrePages > 1 && (
+                <div className='mt-6'>
+                  <Pagination
+                    nomListe='actions'
+                    nombreDePages={nombrePages}
+                    pageCourante={pageCourante}
+                    allerALaPage={changerPage}
+                  />
+                </div>
+              )}
+            </>
           )}
         </>
       )}

--- a/components/agenda-jeune/OngletAgendaBeneficiaire.tsx
+++ b/components/agenda-jeune/OngletAgendaBeneficiaire.tsx
@@ -9,18 +9,19 @@ import { IntegrationPoleEmploi } from 'components/jeune/IntegrationPoleEmploi'
 import IconComponent, { IconName } from 'components/ui/IconComponent'
 import { SpinningLoader } from 'components/ui/SpinningLoader'
 import { Agenda, EntreeAgenda } from 'interfaces/agenda'
+import { Conseiller, isPoleEmploi } from 'interfaces/conseiller'
 import { toFrenchFormat, WEEKDAY_MONTH_LONG } from 'utils/date'
 
 interface OngletAgendaBeneficiaireProps {
   idBeneficiaire: string
-  isPoleEmploi: boolean
+  conseiller: Conseiller
   recupererAgenda: () => Promise<Agenda>
   goToActions: () => void
 }
 
 export function OngletAgendaBeneficiaire({
   idBeneficiaire,
-  isPoleEmploi,
+  conseiller,
   recupererAgenda,
   goToActions,
 }: OngletAgendaBeneficiaireProps) {
@@ -32,7 +33,7 @@ export function OngletAgendaBeneficiaire({
   const [nombreActionsEnRetard, setNombreActionsEnRetard] = useState<number>()
 
   useEffect(() => {
-    if (!isPoleEmploi) {
+    if (!isPoleEmploi(conseiller)) {
       recupererAgenda().then(
         ({
           entrees,
@@ -59,78 +60,90 @@ export function OngletAgendaBeneficiaire({
 
   return (
     <>
-      {isPoleEmploi && (
+      {isPoleEmploi(conseiller) && (
         <IntegrationPoleEmploi label='convocations et démarches' />
       )}
 
-      {!isPoleEmploi && !semaines && <SpinningLoader />}
-
-      {!isPoleEmploi && semaines && (
+      {!isPoleEmploi(conseiller) && (
         <>
-          {Boolean(nombreActionsEnRetard) && (
-            <div className='flex justify-between p-4 mb-6 bg-warning_lighten rounded-base'>
-              <div className='flex gap-2'>
-                <IconComponent
-                  name={IconName.ImportantOutline}
-                  focusable={false}
-                  aria-hidden={true}
-                  className='w-[16px] h-[16px] m-auto accent-warning'
-                />
-                <p>Actions en retard ({nombreActionsEnRetard})</p>
-              </div>
-              <button
-                type='button'
-                onClick={goToActions}
-                className='flex items-center'
-              >
-                Voir
-                <IconComponent
-                  name={IconName.ChevronRight}
-                  className='w-4 h-5'
-                  aria-hidden={true}
-                  focusable={false}
-                />
-                <span className='sr-only'>les actions</span>
-              </button>
-            </div>
+          {!semaines && <SpinningLoader />}
+
+          {semaines && (
+            <>
+              {Boolean(nombreActionsEnRetard) && (
+                <div className='flex justify-between p-4 mb-6 bg-warning_lighten rounded-base'>
+                  <div className='flex gap-2'>
+                    <IconComponent
+                      name={IconName.ImportantOutline}
+                      focusable={false}
+                      aria-hidden={true}
+                      className='w-[16px] h-[16px] m-auto accent-warning'
+                    />
+                    <p>Actions en retard ({nombreActionsEnRetard})</p>
+                  </div>
+                  <button
+                    type='button'
+                    onClick={goToActions}
+                    className='flex items-center'
+                  >
+                    Voir
+                    <IconComponent
+                      name={IconName.ChevronRight}
+                      className='w-4 h-5'
+                      aria-hidden={true}
+                      focusable={false}
+                    />
+                    <span className='sr-only'>les actions</span>
+                  </button>
+                </div>
+              )}
+              <section aria-labelledby='semaine-en-cours'>
+                <h2
+                  id='semaine-en-cours'
+                  className='text-m-bold text-primary mb-6'
+                >
+                  Semaine en cours
+                </h2>
+
+                {!semaines.courante.aEvenement && (
+                  <AucuneEntreeDansLaSemaine
+                    periode={getLibelleSemaineEnCours()}
+                  />
+                )}
+
+                {semaines.courante.aEvenement && (
+                  <EntreesAgendaParJourDeLaSemaine
+                    idBeneficiaire={idBeneficiaire}
+                    numeroSemaine={0}
+                    semaine={semaines.courante}
+                  />
+                )}
+              </section>
+
+              <section aria-labelledby='semaine-suivante' className='mt-6'>
+                <h2
+                  id='semaine-suivante'
+                  className='text-m-bold text-primary mb-6'
+                >
+                  Semaine suivante
+                </h2>
+
+                {!semaines.suivante.aEvenement && (
+                  <AucuneEntreeDansLaSemaine
+                    periode={getLibelleSemaineSuivante()}
+                  />
+                )}
+
+                {semaines.suivante.aEvenement && (
+                  <EntreesAgendaParJourDeLaSemaine
+                    idBeneficiaire={idBeneficiaire}
+                    numeroSemaine={1}
+                    semaine={semaines.suivante}
+                  />
+                )}
+              </section>
+            </>
           )}
-          <section aria-labelledby='semaine-en-cours'>
-            <h2 id='semaine-en-cours' className='text-m-bold text-primary mb-6'>
-              Semaine en cours
-            </h2>
-
-            {!semaines.courante.aEvenement && (
-              <AucuneEntreeDansLaSemaine periode={getLibelleSemaineEnCours()} />
-            )}
-
-            {semaines.courante.aEvenement && (
-              <EntreesAgendaParJourDeLaSemaine
-                idBeneficiaire={idBeneficiaire}
-                numeroSemaine={0}
-                semaine={semaines.courante}
-              />
-            )}
-          </section>
-
-          <section aria-labelledby='semaine-suivante' className='mt-6'>
-            <h2 id='semaine-suivante' className='text-m-bold text-primary mb-6'>
-              Semaine suivante
-            </h2>
-
-            {!semaines.suivante.aEvenement && (
-              <AucuneEntreeDansLaSemaine
-                periode={getLibelleSemaineSuivante()}
-              />
-            )}
-
-            {semaines.suivante.aEvenement && (
-              <EntreesAgendaParJourDeLaSemaine
-                idBeneficiaire={idBeneficiaire}
-                numeroSemaine={1}
-                semaine={semaines.suivante}
-              />
-            )}
-          </section>
         </>
       )}
     </>

--- a/components/agenda-jeune/OngletAgendaBeneficiaire.tsx
+++ b/components/agenda-jeune/OngletAgendaBeneficiaire.tsx
@@ -9,7 +9,7 @@ import { IntegrationPoleEmploi } from 'components/jeune/IntegrationPoleEmploi'
 import IconComponent, { IconName } from 'components/ui/IconComponent'
 import { SpinningLoader } from 'components/ui/SpinningLoader'
 import { Agenda, EntreeAgenda } from 'interfaces/agenda'
-import { Conseiller, isPoleEmploi } from 'interfaces/conseiller'
+import { Conseiller, estPoleEmploi } from 'interfaces/conseiller'
 import { toFrenchFormat, WEEKDAY_MONTH_LONG } from 'utils/date'
 
 interface OngletAgendaBeneficiaireProps {
@@ -33,7 +33,7 @@ export function OngletAgendaBeneficiaire({
   const [nombreActionsEnRetard, setNombreActionsEnRetard] = useState<number>()
 
   useEffect(() => {
-    if (!isPoleEmploi(conseiller)) {
+    if (!estPoleEmploi(conseiller)) {
       recupererAgenda().then(
         ({
           entrees,
@@ -60,11 +60,11 @@ export function OngletAgendaBeneficiaire({
 
   return (
     <>
-      {isPoleEmploi(conseiller) && (
+      {estPoleEmploi(conseiller) && (
         <IntegrationPoleEmploi label='convocations et démarches' />
       )}
 
-      {!isPoleEmploi(conseiller) && (
+      {!estPoleEmploi(conseiller) && (
         <>
           {!semaines && <SpinningLoader />}
 

--- a/components/chat/ChatRoom.tsx
+++ b/components/chat/ChatRoom.tsx
@@ -34,7 +34,7 @@ export default function ChatRoom({
   function toggleFlag(idChat: string, flagged: boolean): void {
     messagesService.toggleFlag(idChat, flagged)
     trackEvent({
-      structure: conseiller!.structure,
+      structure: conseiller.structure,
       categorie: 'Conversation suivie',
       action: 'ChatRoom',
       nom: flagged.toString(),

--- a/components/chat/Conversation.tsx
+++ b/components/chat/Conversation.tsx
@@ -192,7 +192,7 @@ export default function Conversation({
     const flagged = !jeuneChat.flaggedByConseiller
     messagesService.toggleFlag(jeuneChat.chatId, flagged)
     trackEvent({
-      structure: conseiller!.structure,
+      structure: conseiller.structure,
       categorie: 'Conversation suivie',
       action: 'Conversation',
       nom: flagged.toString(),

--- a/components/jeune/AjouterJeuneButton.tsx
+++ b/components/jeune/AjouterJeuneButton.tsx
@@ -5,7 +5,7 @@ import IconComponent, { IconName } from 'components/ui/IconComponent'
 import { StructureConseiller } from 'interfaces/conseiller'
 
 interface AjouterJeuneButtonProps {
-  structure?: StructureConseiller
+  structure: StructureConseiller
 }
 
 export const AjouterJeuneButton = ({ structure }: AjouterJeuneButtonProps) => {

--- a/components/jeune/BlocInformationJeune.tsx
+++ b/components/jeune/BlocInformationJeune.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link'
 import React, { useMemo } from 'react'
 
 import IconComponent, { IconName } from 'components/ui/IconComponent'
-import { StructureConseiller } from 'interfaces/conseiller'
+import { Conseiller, estMilo } from 'interfaces/conseiller'
 import { toShortDate } from 'utils/date'
 
 interface BlocInformationJeuneProps {
@@ -10,7 +10,7 @@ interface BlocInformationJeuneProps {
   creationDate: string
   dateFinCEJ: string | undefined
   email: string | undefined
-  structureConseiller: StructureConseiller | undefined
+  conseiller: Conseiller
   onIdentifiantPartenaireCopie: () => void
   identifiantPartenaire: string | undefined
   onIdentifiantPartenaireClick: () => void
@@ -23,13 +23,14 @@ export function BlocInformationJeune({
   creationDate,
   dateFinCEJ,
   email,
-  structureConseiller,
+  conseiller,
   onIdentifiantPartenaireCopie,
   identifiantPartenaire,
   onIdentifiantPartenaireClick,
   urlDossier,
   onDossierMiloClick,
 }: BlocInformationJeuneProps) {
+  const conseillerEstMilo = estMilo(conseiller)
   const shortCreationDate = useMemo(
     () => toShortDate(creationDate),
     [creationDate]
@@ -48,7 +49,7 @@ export function BlocInformationJeune({
 
         {email && <Email email={email} />}
 
-        {structureConseiller !== StructureConseiller.MILO && (
+        {!conseillerEstMilo && (
           <IndentifiantPartenaire
             identifiantPartenaire={identifiantPartenaire}
             onCopy={onIdentifiantPartenaireCopie}
@@ -60,7 +61,7 @@ export function BlocInformationJeune({
           <DossierExterne href={urlDossier} onClick={onDossierMiloClick} />
         )}
 
-        {structureConseiller === StructureConseiller.MILO && (
+        {conseillerEstMilo && (
           <div className='flex'>
             <dt className='text-base-regular'>Date de fin du CEJ :</dt>
             <dd>
@@ -72,9 +73,7 @@ export function BlocInformationJeune({
         )}
       </dl>
 
-      {structureConseiller !== StructureConseiller.MILO && (
-        <LienVersHistorique idJeune={idJeune} />
-      )}
+      {!conseillerEstMilo && <LienVersHistorique idJeune={idJeune} />}
     </div>
   )
 }

--- a/components/jeune/DetailsJeune.tsx
+++ b/components/jeune/DetailsJeune.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react'
 import { BlocInformationJeune } from 'components/jeune/BlocInformationJeune'
 import { BlocSituation } from 'components/jeune/BlocSituation'
 import UpdateIdentifiantPartenaireModal from 'components/jeune/UpdateIdentifiantPartenaireModal'
-import { StructureConseiller } from 'interfaces/conseiller'
+import { Conseiller, estMilo, StructureConseiller } from 'interfaces/conseiller'
 import { DetailJeune } from 'interfaces/jeune'
 import { AlerteParam } from 'referentiel/alerteParam'
 import { JeunesService } from 'services/jeunes.service'
@@ -13,13 +13,13 @@ import { useDependance } from 'utils/injectionDependances'
 
 interface DetailsJeuneProps {
   jeune: DetailJeune
-  structureConseiller: StructureConseiller | undefined
+  conseiller: Conseiller
   onDossierMiloClick: () => void
 }
 
 export const DetailsJeune = ({
   jeune,
-  structureConseiller,
+  conseiller,
   onDossierMiloClick,
 }: DetailsJeuneProps) => {
   const jeunesService = useDependance<JeunesService>('jeunesService')
@@ -66,7 +66,7 @@ export const DetailsJeune = ({
   return (
     <>
       <div className='flex flex-row items-stretch gap-x-6'>
-        {structureConseiller === StructureConseiller.MILO && (
+        {estMilo(conseiller) && (
           <BlocSituation
             idJeune={jeune.id}
             situations={jeune.situations}
@@ -79,7 +79,7 @@ export const DetailsJeune = ({
           creationDate={jeune.creationDate}
           dateFinCEJ={jeune.dateFinCEJ}
           email={jeune.email}
-          structureConseiller={structureConseiller}
+          conseiller={conseiller}
           onIdentifiantPartenaireCopie={trackEventOnCopieIdentifiantPartenaire}
           identifiantPartenaire={identifiantPartenaire}
           onIdentifiantPartenaireClick={openIdentifiantPartenaireModal}

--- a/components/layouts/AlerteDisplayer.tsx
+++ b/components/layouts/AlerteDisplayer.tsx
@@ -15,7 +15,7 @@ export default function AlerteDisplayer({
   hideOnLargeScreen = false,
 }: AlerteDisplayerProps) {
   const [conseiller] = useConseiller()
-  const [alertes, setAlertes] = useState<DictAlertes>(ALERTES)
+  const alertes = getAlertesForStructure(conseiller.structure)
 
   const [alerte, setAlerte] = useAlerte()
   const [alerteAAfficher, setAlerteAAfficher] = useState<
@@ -25,12 +25,6 @@ export default function AlerteDisplayer({
   async function closeAlerte(): Promise<void> {
     setAlerte(undefined)
   }
-
-  useEffect(() => {
-    if (conseiller?.structure) {
-      setAlertes(getAlertesForStructure(conseiller.structure))
-    }
-  }, [conseiller?.structure])
 
   useEffect(() => {
     setAlerteAAfficher(alerte && alertes[alerte.key])

--- a/components/layouts/ChatManager.tsx
+++ b/components/layouts/ChatManager.tsx
@@ -54,7 +54,7 @@ export default function ChatManager({
   }, [chatCredentials, messagesService, setChatCredentials])
 
   useEffect(() => {
-    if (!chatCredentials || !conseiller || !audio) return
+    if (!chatCredentials || !audio) return
     messagesService
       .signIn(chatCredentials.token)
       .then(() => jeunesService.getJeunesDuConseillerClientSide())
@@ -92,18 +92,11 @@ export default function ChatManager({
 
     function doitEmettreUnSon(previousChat: JeuneChat, updatedChat: JeuneChat) {
       return (
-        conseiller?.notificationsSonores &&
+        conseiller.notificationsSonores &&
         aUnNouveauMessage(previousChat, updatedChat)
       )
     }
-  }, [
-    messagesService,
-    chatCredentials,
-    audio,
-    conseiller,
-    setHasMessageNonLu,
-    jeunesService,
-  ])
+  }, [chatCredentials, audio, conseiller.notificationsSonores])
 
   return displayChat ? <ChatContainer jeunesChats={chats} /> : <></>
 }

--- a/components/layouts/Layout.tsx
+++ b/components/layouts/Layout.tsx
@@ -13,6 +13,7 @@ import Footer from 'components/layouts/Footer'
 import { Header } from 'components/layouts/Header'
 import Sidebar from 'components/layouts/Sidebar'
 import { MODAL_ROOT_ID } from 'components/Modal'
+import { SpinningLoader } from 'components/ui/SpinningLoader'
 import { PageProps } from 'interfaces/pageProps'
 import { ConseillerService } from 'services/conseiller.service'
 import styles from 'styles/components/Layouts.module.css'
@@ -98,7 +99,9 @@ export default function Layout({ children }: LayoutProps) {
             }`}
           >
             <AlerteDisplayer />
-            {children}
+
+            {!conseiller && <SpinningLoader />}
+            {conseiller && children}
           </main>
 
           <Footer />

--- a/components/layouts/Layout.tsx
+++ b/components/layouts/Layout.tsx
@@ -17,7 +17,7 @@ import { SpinningLoader } from 'components/ui/SpinningLoader'
 import { PageProps } from 'interfaces/pageProps'
 import { ConseillerService } from 'services/conseiller.service'
 import styles from 'styles/components/Layouts.module.css'
-import { useConseiller } from 'utils/conseiller/conseillerContext'
+import { useConseillerPotentiellementPasRecupere } from 'utils/conseiller/conseillerContext'
 import { useDependance } from 'utils/injectionDependances'
 
 interface LayoutProps {
@@ -32,7 +32,7 @@ export default function Layout({ children }: LayoutProps) {
   const router = useRouter()
   const conseillerService =
     useDependance<ConseillerService>('conseillerService')
-  const [conseiller, setConseiller] = useConseiller()
+  const [conseiller, setConseiller] = useConseillerPotentiellementPasRecupere()
 
   const containerRef = useRef<HTMLDivElement>(null)
   const mainRef = useRef<HTMLDivElement>(null)
@@ -75,42 +75,50 @@ export default function Layout({ children }: LayoutProps) {
   return (
     <>
       <AppHead hasMessageNonLu={hasMessageNonLu} titre={pageTitle} />
-      <div
-        ref={containerRef}
-        className={`${styles.container} ${
-          withChat ? styles.container_with_chat : ''
-        }`}
-      >
-        <Sidebar />
-        <div
-          ref={mainRef}
-          className={`${styles.page} ${withChat ? styles.page_when_chat : ''}`}
-        >
-          <Header
-            currentPath={router.asPath}
-            returnTo={returnTo}
-            pageHeader={pageHeader ?? pageTitle}
-          />
 
-          <main
-            role='main'
-            className={`${styles.content} ${
-              withChat ? styles.content_when_chat : ''
+      {!conseiller && <SpinningLoader />}
+
+      {conseiller && (
+        <div
+          ref={containerRef}
+          className={`${styles.container} ${
+            withChat ? styles.container_with_chat : ''
+          }`}
+        >
+          <Sidebar />
+
+          <div
+            ref={mainRef}
+            className={`${styles.page} ${
+              withChat ? styles.page_when_chat : ''
             }`}
           >
-            <AlerteDisplayer />
+            <Header
+              currentPath={router.asPath}
+              returnTo={returnTo}
+              pageHeader={pageHeader ?? pageTitle}
+            />
 
-            {!conseiller && <SpinningLoader />}
-            {conseiller && children}
-          </main>
+            <main
+              role='main'
+              className={`${styles.content} ${
+                withChat ? styles.content_when_chat : ''
+              }`}
+            >
+              <AlerteDisplayer />
+              {children}
+            </main>
 
-          <Footer />
+            <Footer />
+          </div>
+
+          <ChatManager
+            displayChat={withChat}
+            setHasMessageNonLu={setHasMessageNonLu}
+          />
         </div>
-        <ChatManager
-          displayChat={withChat}
-          setHasMessageNonLu={setHasMessageNonLu}
-        />
-      </div>
+      )}
+
       <div id={MODAL_ROOT_ID} />
     </>
   )

--- a/components/rdv/EditionRdvForm.tsx
+++ b/components/rdv/EditionRdvForm.tsx
@@ -41,6 +41,7 @@ import {
 } from 'utils/date'
 
 interface EditionRdvFormProps {
+  conseiller: Conseiller
   jeunesConseiller: BaseJeune[]
   typesRendezVous: TypeEvenement[]
   redirectTo: string
@@ -48,8 +49,6 @@ interface EditionRdvFormProps {
   soumettreRendezVous: (payload: EvenementFormData) => Promise<void>
   leaveWithChanges: () => void
   onChanges: (hasChanges: boolean) => void
-  // TODO
-  conseiller?: Conseiller
   evenement?: Evenement
   idJeune?: string
   showConfirmationModal: (payload: EvenementFormData) => void
@@ -457,7 +456,7 @@ export function EditionRdvForm({
 
   function emailInvitationText() {
     if (conseillerIsCreator) {
-      return `Intégrer cet événement à mon agenda via l’adresse e-mail suivante : ${conseiller?.email}`
+      return `Intégrer cet événement à mon agenda via l’adresse e-mail suivante : ${conseiller.email}`
     } else {
       return "Le créateur de l’événement recevra un mail pour l'informer de la modification."
     }

--- a/components/rdv/EditionRdvForm.tsx
+++ b/components/rdv/EditionRdvForm.tsx
@@ -48,6 +48,7 @@ interface EditionRdvFormProps {
   soumettreRendezVous: (payload: EvenementFormData) => Promise<void>
   leaveWithChanges: () => void
   onChanges: (hasChanges: boolean) => void
+  // TODO
   conseiller?: Conseiller
   evenement?: Evenement
   idJeune?: string

--- a/components/rdv/OngletRdvsBeneficiaire.tsx
+++ b/components/rdv/OngletRdvsBeneficiaire.tsx
@@ -1,33 +1,35 @@
 import Link from 'next/link'
 import React from 'react'
 
-import IconComponent, { IconName } from '../ui/IconComponent'
-
 import { IntegrationPoleEmploi } from 'components/jeune/IntegrationPoleEmploi'
 import TableauRdv from 'components/rdv/TableauRdv'
+import IconComponent, { IconName } from 'components/ui/IconComponent'
+import { Conseiller, isPoleEmploi } from 'interfaces/conseiller'
 import { EvenementListItem } from 'interfaces/evenement'
 import { BaseJeune } from 'interfaces/jeune'
 
 interface OngletRdvsBeneficiaireProps {
   rdvs: EvenementListItem[]
   beneficiaire: BaseJeune
-  poleEmploi: boolean
-  idConseiller: string
+  conseiller: Conseiller
 }
 
 export function OngletRdvsBeneficiaire({
-  idConseiller,
-  beneficiaire,
-  poleEmploi,
   rdvs,
+  beneficiaire,
+  conseiller,
 }: OngletRdvsBeneficiaireProps) {
   return (
     <>
-      {!poleEmploi ? (
+      {isPoleEmploi(conseiller) && (
+        <IntegrationPoleEmploi label='convocations' />
+      )}
+
+      {!isPoleEmploi(conseiller) && (
         <>
           <TableauRdv
             rdvs={rdvs}
-            idConseiller={idConseiller}
+            idConseiller={conseiller.id}
             beneficiaireUnique={beneficiaire}
             additionalColumns='Modalité'
           />
@@ -44,8 +46,6 @@ export function OngletRdvsBeneficiaire({
             />
           </Link>
         </>
-      ) : (
-        <IntegrationPoleEmploi label='convocations' />
       )}
     </>
   )

--- a/components/rdv/OngletRdvsBeneficiaire.tsx
+++ b/components/rdv/OngletRdvsBeneficiaire.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import { IntegrationPoleEmploi } from 'components/jeune/IntegrationPoleEmploi'
 import TableauRdv from 'components/rdv/TableauRdv'
 import IconComponent, { IconName } from 'components/ui/IconComponent'
-import { Conseiller, isPoleEmploi } from 'interfaces/conseiller'
+import { Conseiller, estPoleEmploi } from 'interfaces/conseiller'
 import { EvenementListItem } from 'interfaces/evenement'
 import { BaseJeune } from 'interfaces/jeune'
 
@@ -21,11 +21,11 @@ export function OngletRdvsBeneficiaire({
 }: OngletRdvsBeneficiaireProps) {
   return (
     <>
-      {isPoleEmploi(conseiller) && (
+      {estPoleEmploi(conseiller) && (
         <IntegrationPoleEmploi label='convocations' />
       )}
 
-      {!isPoleEmploi(conseiller) && (
+      {!estPoleEmploi(conseiller) && (
         <>
           <TableauRdv
             rdvs={rdvs}

--- a/interfaces/conseiller.ts
+++ b/interfaces/conseiller.ts
@@ -24,9 +24,13 @@ export interface Conseiller {
   agence?: { nom: string; id?: string }
 }
 
-export function isPoleEmploi(conseiller: Conseiller): boolean {
+export function estPoleEmploi(conseiller: Conseiller): boolean {
   return conseiller.structure === StructureConseiller.POLE_EMPLOI
 }
-export function isMilo(conseiller: Conseiller): boolean {
+export function estMilo(conseiller: Conseiller): boolean {
   return conseiller.structure === StructureConseiller.MILO
+}
+
+export function estSuperviseur(conseiller: Conseiller): boolean {
+  return conseiller.estSuperviseur
 }

--- a/interfaces/conseiller.ts
+++ b/interfaces/conseiller.ts
@@ -23,3 +23,10 @@ export interface Conseiller {
   email?: string
   agence?: { nom: string; id?: string }
 }
+
+export function isPoleEmploi(conseiller: Conseiller): boolean {
+  return conseiller.structure === StructureConseiller.POLE_EMPLOI
+}
+export function isMilo(conseiller: Conseiller): boolean {
+  return conseiller.structure === StructureConseiller.MILO
+}

--- a/pages/agenda.tsx
+++ b/pages/agenda.tsx
@@ -127,7 +127,7 @@ function Agenda({ onglet }: AgendaProps) {
     nom: string
   }): Promise<void> {
     await conseillerService.modifierAgence(agence)
-    setConseiller({ ...conseiller!, agence })
+    setConseiller({ ...conseiller, agence })
     setTrackingTitle(initialTracking + ' - Succès ajout agence')
   }
 
@@ -155,7 +155,7 @@ function Agenda({ onglet }: AgendaProps) {
           Créer un rendez-vous
         </ButtonLink>
 
-        {conseiller && conseiller.agence && (
+        {conseiller.agence && (
           <ButtonLink href='/mes-jeunes/edition-rdv?type=ac'>
             <IconComponent
               name={IconName.Add}
@@ -194,7 +194,7 @@ function Agenda({ onglet }: AgendaProps) {
           id='agenda-conseiller'
         >
           <OngletAgendaConseiller
-            idConseiller={conseiller?.id}
+            idConseiller={conseiller.id}
             recupererRdvs={recupererRdvsConseiller}
             trackNavigation={trackNavigation}
           />
@@ -208,15 +208,15 @@ function Agenda({ onglet }: AgendaProps) {
           tabIndex={0}
           id='agenda-etablissement'
         >
-          {conseiller && conseiller.agence && (
+          {conseiller.agence && (
             <OngletAgendaEtablissement
-              idEtablissement={conseiller?.agence?.id}
+              idEtablissement={conseiller.agence?.id}
               recupererAnimationsCollectives={recupererRdvsEtablissement}
               trackNavigation={trackNavigation}
             />
           )}
 
-          {conseiller && !conseiller.agence && (
+          {!conseiller.agence && (
             <EncartAgenceRequise
               structureConseiller={conseiller.structure}
               onAgenceChoisie={renseignerAgence}

--- a/pages/agenda.tsx
+++ b/pages/agenda.tsx
@@ -218,7 +218,7 @@ function Agenda({ onglet }: AgendaProps) {
 
           {!conseiller.agence && (
             <EncartAgenceRequise
-              structureConseiller={conseiller.structure}
+              conseiller={conseiller}
               onAgenceChoisie={renseignerAgence}
               getAgences={referentielService.getAgencesClientSide.bind(
                 referentielService

--- a/pages/etablissement.tsx
+++ b/pages/etablissement.tsx
@@ -46,7 +46,7 @@ const Etablissement = (_: MissionLocaleProps) => {
   const [metadonnees, setMetadonnees] = useState<MetadonneesPagination>()
   const [pageCourante, setPageCourante] = useState<number>()
 
-  const isMilo = conseiller?.structure === StructureConseiller.MILO
+  const isMilo = conseiller.structure === StructureConseiller.MILO
 
   async function rechercherJeunes(input: string, page: number) {
     if (!input) {
@@ -54,7 +54,7 @@ const Etablissement = (_: MissionLocaleProps) => {
       setMetadonnees(undefined)
     } else if (nouvelleRecherche(input, page)) {
       const resultats = await jeunesService.rechercheJeunesDeLEtablissement(
-        conseiller!.agence!.id!,
+        conseiller.agence!.id!,
         input,
         page
       )
@@ -71,7 +71,7 @@ const Etablissement = (_: MissionLocaleProps) => {
     nom: string
   }): Promise<void> {
     await conseillerService.modifierAgence(agence)
-    setConseiller({ ...conseiller!, agence })
+    setConseiller({ ...conseiller, agence })
     setTrackingTitle(initialTracking + ' - Succès ajout agence')
   }
 
@@ -87,14 +87,14 @@ const Etablissement = (_: MissionLocaleProps) => {
 
   return (
     <>
-      {Boolean(conseiller?.agence) && (
+      {Boolean(conseiller.agence) && (
         <RechercheJeune
           onSearchFilterBy={(input) => rechercherJeunes(input, 1)}
           minCaracteres={2}
         />
       )}
 
-      {conseiller && !conseiller?.agence && (
+      {!conseiller.agence && (
         <EncartAgenceRequise
           structureConseiller={conseiller.structure}
           onAgenceChoisie={renseignerAgence}

--- a/pages/etablissement.tsx
+++ b/pages/etablissement.tsx
@@ -13,7 +13,7 @@ import TD from 'components/ui/Table/TD'
 import { TH } from 'components/ui/Table/TH'
 import { THead } from 'components/ui/Table/THead'
 import { TR } from 'components/ui/Table/TR'
-import { StructureConseiller } from 'interfaces/conseiller'
+import { estMilo, StructureConseiller } from 'interfaces/conseiller'
 import { getNomJeuneComplet, JeuneEtablissement } from 'interfaces/jeune'
 import { PageProps } from 'interfaces/pageProps'
 import { ConseillerService } from 'services/conseiller.service'
@@ -46,7 +46,7 @@ const Etablissement = (_: MissionLocaleProps) => {
   const [metadonnees, setMetadonnees] = useState<MetadonneesPagination>()
   const [pageCourante, setPageCourante] = useState<number>()
 
-  const isMilo = conseiller.structure === StructureConseiller.MILO
+  const conseillerEstMilo = estMilo(conseiller)
 
   async function rechercherJeunes(input: string, page: number) {
     if (!input) {
@@ -96,7 +96,7 @@ const Etablissement = (_: MissionLocaleProps) => {
 
       {!conseiller.agence && (
         <EncartAgenceRequise
-          structureConseiller={conseiller.structure}
+          conseiller={conseiller}
           onAgenceChoisie={renseignerAgence}
           getAgences={referentielService.getAgencesClientSide.bind(
             referentielService
@@ -118,7 +118,7 @@ const Etablissement = (_: MissionLocaleProps) => {
             <THead>
               <TR isHeader={true}>
                 <TH>Bénéficiaire</TH>
-                {isMilo && <TH>Situation</TH>}
+                {conseillerEstMilo && <TH>Situation</TH>}
                 <TH>Dernière activité</TH>
                 <TH>Conseiller</TH>
               </TR>
@@ -127,7 +127,7 @@ const Etablissement = (_: MissionLocaleProps) => {
               {resultatsRecherche!.map((jeune) => (
                 <TR key={jeune.base.id}>
                   <TD isBold>{getNomJeuneComplet(jeune.base)}</TD>
-                  {isMilo && (
+                  {conseillerEstMilo && (
                     <TD>
                       {jeune.situation && (
                         <SituationTag situation={jeune.situation} />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -39,7 +39,7 @@ function Home({ redirectUrl, referentielAgences }: HomePageProps) {
     nom: string
   }): Promise<void> {
     await conseillerService.modifierAgence(agence)
-    setConseiller({ ...conseiller!, agence })
+    setConseiller({ ...conseiller, agence })
     setTrackingLabel('Succès ajout agence')
     setAlerte(AlerteParam.choixAgence)
     redirectToUrl()
@@ -51,7 +51,7 @@ function Home({ redirectUrl, referentielAgences }: HomePageProps) {
 
   function trackContacterSupport() {
     trackEvent({
-      structure: conseiller!.structure,
+      structure: conseiller.structure,
       categorie: 'Contact Support',
       action: 'Pop-in sélection agence',
       nom: '',
@@ -62,9 +62,7 @@ function Home({ redirectUrl, referentielAgences }: HomePageProps) {
 
   return (
     <RenseignementAgenceModal
-      structureConseiller={
-        conseiller?.structure ?? StructureConseiller.PASS_EMPLOI
-      }
+      structureConseiller={conseiller.structure}
       referentielAgences={referentielAgences}
       onAgenceChoisie={selectAgence}
       onContacterSupport={trackContacterSupport}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -62,7 +62,7 @@ function Home({ redirectUrl, referentielAgences }: HomePageProps) {
 
   return (
     <RenseignementAgenceModal
-      structureConseiller={conseiller.structure}
+      conseiller={conseiller}
       referentielAgences={referentielAgences}
       onAgenceChoisie={selectAgence}
       onContacterSupport={trackContacterSupport}

--- a/pages/mes-jeunes.tsx
+++ b/pages/mes-jeunes.tsx
@@ -10,7 +10,11 @@ import PageActionsPortal from 'components/PageActionsPortal'
 import Button from 'components/ui/Button/Button'
 import { SpinningLoader } from 'components/ui/SpinningLoader'
 import { TotalActions } from 'interfaces/action'
-import { StructureConseiller } from 'interfaces/conseiller'
+import {
+  estMilo,
+  estPoleEmploi,
+  StructureConseiller,
+} from 'interfaces/conseiller'
 import {
   compareJeunesByNom,
   JeuneAvecInfosComplementaires,
@@ -70,7 +74,7 @@ function MesJeunes({ conseillerJeunes, isFromEmail }: MesJeunesProps) {
     try {
       await conseillerService.recupererBeneficiaires()
       setAlerte(AlerteParam.recuperationBeneficiaires)
-      setConseiller({ ...conseiller!, aDesBeneficiairesARecuperer: false })
+      setConseiller({ ...conseiller, aDesBeneficiairesARecuperer: false })
     } finally {
       setIsRecuperationBeneficiairesLoading(false)
     }
@@ -137,10 +141,10 @@ function MesJeunes({ conseillerJeunes, isFromEmail }: MesJeunesProps) {
   return (
     <>
       <PageActionsPortal>
-        <AjouterJeuneButton structure={conseiller?.structure} />
+        <AjouterJeuneButton structure={conseiller.structure} />
       </PageActionsPortal>
 
-      {conseiller?.aDesBeneficiairesARecuperer && (
+      {conseiller.aDesBeneficiairesARecuperer && (
         <div className='bg-primary_lighten rounded-base p-6 mb-6 text-center'>
           <p className='text-base-bold text-primary'>
             {conseillerJeunes.length > 0 &&
@@ -160,7 +164,7 @@ function MesJeunes({ conseillerJeunes, isFromEmail }: MesJeunesProps) {
       )}
 
       {conseillerJeunes.length === 0 &&
-        !conseiller?.aDesBeneficiairesARecuperer && (
+        !conseiller.aDesBeneficiairesARecuperer && (
           <div className='mx-auto my-0 flex flex-col items-center'>
             <EmptyStateImage
               aria-hidden='true'
@@ -185,12 +189,8 @@ function MesJeunes({ conseillerJeunes, isFromEmail }: MesJeunesProps) {
             <TableauJeunes
               jeunesFiltres={jeunesFiltres}
               totalJeunes={conseillerJeunes.length}
-              withActions={
-                conseiller?.structure !== StructureConseiller.POLE_EMPLOI
-              }
-              withSituations={
-                conseiller?.structure === StructureConseiller.MILO
-              }
+              withActions={!estPoleEmploi(conseiller)}
+              withSituations={estMilo(conseiller)}
             />
           )}
         </>

--- a/pages/mes-jeunes/[jeune_id].tsx
+++ b/pages/mes-jeunes/[jeune_id].tsx
@@ -26,7 +26,11 @@ import {
   StatutAction,
 } from 'interfaces/action'
 import { Agenda } from 'interfaces/agenda'
-import { estPoleEmploi, StructureConseiller } from 'interfaces/conseiller'
+import {
+  estMilo,
+  estPoleEmploi,
+  StructureConseiller,
+} from 'interfaces/conseiller'
 import { EvenementListItem, PeriodeEvenements } from 'interfaces/evenement'
 import {
   DetailJeune,
@@ -286,17 +290,16 @@ function FicheJeune({
         <FailureAlert label='Ce bénéficiaire ne s’est pas encore connecté à l’application' />
       )}
 
-      {!jeune.isActivated &&
-        conseiller.structure === StructureConseiller.MILO && (
-          <div className='mb-8'>
-            <InformationMessage label='Le lien d’activation est valable 12h.'>
-              <p>
-                Si le délai est dépassé, veuillez orienter ce bénéficiaire vers
-                l’option : mot de passe oublié.
-              </p>
-            </InformationMessage>
-          </div>
-        )}
+      {!jeune.isActivated && estMilo(conseiller) && (
+        <div className='mb-8'>
+          <InformationMessage label='Le lien d’activation est valable 12h.'>
+            <p>
+              Si le délai est dépassé, veuillez orienter ce bénéficiaire vers
+              l’option : mot de passe oublié.
+            </p>
+          </InformationMessage>
+        </div>
+      )}
 
       {jeune.isReaffectationTemporaire && (
         <div className='mb-6'>
@@ -310,7 +313,7 @@ function FicheJeune({
       <div className='mb-6'>
         <DetailsJeune
           jeune={jeune}
-          structureConseiller={conseiller.structure}
+          conseiller={conseiller}
           onDossierMiloClick={trackDossierMiloClick}
         />
       </div>

--- a/pages/mes-jeunes/[jeune_id].tsx
+++ b/pages/mes-jeunes/[jeune_id].tsx
@@ -26,7 +26,7 @@ import {
   StatutAction,
 } from 'interfaces/action'
 import { Agenda } from 'interfaces/agenda'
-import { isPoleEmploi, StructureConseiller } from 'interfaces/conseiller'
+import { estPoleEmploi, StructureConseiller } from 'interfaces/conseiller'
 import { EvenementListItem, PeriodeEvenements } from 'interfaces/evenement'
 import {
   DetailJeune,
@@ -46,7 +46,7 @@ import { useAlerte } from 'utils/alerteContext'
 import useMatomo from 'utils/analytics/useMatomo'
 import { withMandatorySessionOrRedirect } from 'utils/auth/withMandatorySessionOrRedirect'
 import { useCurrentJeune } from 'utils/chat/currentJeuneContext'
-import { useForcedConseiller } from 'utils/conseiller/conseillerContext'
+import { useConseiller } from 'utils/conseiller/conseillerContext'
 import { useDependance } from 'utils/injectionDependances'
 import withDependance from 'utils/injectionDependances/withDependance'
 
@@ -90,7 +90,7 @@ function FicheJeune({
   const agendaService = useDependance<AgendaService>('agendaService')
   const router = useRouter()
   const [, setIdCurrentJeune] = useCurrentJeune()
-  const [conseiller] = useForcedConseiller()
+  const [conseiller] = useConseiller()
   const [alerte, setAlerte] = useAlerte()
 
   const [motifsSuppression, setMotifsSuppression] = useState<
@@ -242,7 +242,7 @@ function FicheJeune({
 
   // On récupère les indicateurs ici parce qu'on a besoin de la timezone du navigateur
   useEffect(() => {
-    if (!isPoleEmploi(conseiller) && !indicateursSemaine) {
+    if (!estPoleEmploi(conseiller) && !indicateursSemaine) {
       jeunesService
         .getIndicateursJeuneAlleges(
           conseiller.id,
@@ -315,7 +315,7 @@ function FicheJeune({
         />
       </div>
 
-      {!isPoleEmploi(conseiller) && (
+      {!estPoleEmploi(conseiller) && (
         <>
           <ResumeIndicateursJeune
             idJeune={jeune.id}
@@ -377,7 +377,7 @@ function FicheJeune({
         />
         <Tab
           label='Actions'
-          count={!isPoleEmploi(conseiller) ? totalActions : undefined}
+          count={!estPoleEmploi(conseiller) ? totalActions : undefined}
           selected={currentTab === Onglet.ACTIONS}
           controls='liste-actions'
           onSelectTab={() => switchTab(Onglet.ACTIONS)}
@@ -385,7 +385,7 @@ function FicheJeune({
         />
         <Tab
           label='Rendez-vous'
-          count={!isPoleEmploi(conseiller) ? rdvs.length : undefined}
+          count={!estPoleEmploi(conseiller) ? rdvs.length : undefined}
           selected={currentTab === Onglet.RDVS}
           controls='liste-rdvs'
           onSelectTab={() => switchTab(Onglet.RDVS)}

--- a/pages/mes-jeunes/[jeune_id]/actions/[action_id].tsx
+++ b/pages/mes-jeunes/[jeune_id]/actions/[action_id].tsx
@@ -60,10 +60,10 @@ function PageAction({ action, jeune, commentaires }: PageActionProps) {
   )
   const estAQualifier: boolean = useMemo(
     () =>
-      conseiller?.structure === StructureConseiller.MILO &&
+      conseiller.structure === StructureConseiller.MILO &&
       statut === StatutAction.Terminee &&
       !qualification,
-    [conseiller?.structure, qualification, statut]
+    [qualification, statut]
   )
   const afficherSuppressionAction = useMemo(
     () =>
@@ -172,7 +172,7 @@ function PageAction({ action, jeune, commentaires }: PageActionProps) {
         />
       )}
 
-      {conseiller?.structure === StructureConseiller.MILO && (
+      {conseiller.structure === StructureConseiller.MILO && (
         <TagQualificationAction statut={statut} qualification={qualification} />
       )}
 

--- a/pages/mes-jeunes/[jeune_id]/actions/[action_id].tsx
+++ b/pages/mes-jeunes/[jeune_id]/actions/[action_id].tsx
@@ -18,7 +18,7 @@ import {
   QualificationAction,
   StatutAction,
 } from 'interfaces/action'
-import { StructureConseiller, UserType } from 'interfaces/conseiller'
+import { estMilo, StructureConseiller, UserType } from 'interfaces/conseiller'
 import { BaseJeune } from 'interfaces/jeune'
 import { CODE_QUALIFICATION_NON_SNP } from 'interfaces/json/action'
 import { PageProps } from 'interfaces/pageProps'
@@ -54,15 +54,15 @@ function PageAction({ action, jeune, commentaires }: PageActionProps) {
 
   const pageTracking = 'Détail Action'
 
+  const conseillerEstMilo = estMilo(conseiller)
+
   const estARealiser: boolean = useMemo(
     () => statut !== StatutAction.Terminee && statut !== StatutAction.Annulee,
     [statut]
   )
   const estAQualifier: boolean = useMemo(
     () =>
-      conseiller.structure === StructureConseiller.MILO &&
-      statut === StatutAction.Terminee &&
-      !qualification,
+      conseillerEstMilo && statut === StatutAction.Terminee && !qualification,
     [qualification, statut]
   )
   const afficherSuppressionAction = useMemo(
@@ -172,7 +172,7 @@ function PageAction({ action, jeune, commentaires }: PageActionProps) {
         />
       )}
 
-      {conseiller.structure === StructureConseiller.MILO && (
+      {conseillerEstMilo && (
         <TagQualificationAction statut={statut} qualification={qualification} />
       )}
 

--- a/pages/mes-jeunes/[jeune_id]/historique.tsx
+++ b/pages/mes-jeunes/[jeune_id]/historique.tsx
@@ -46,14 +46,14 @@ function Historique({ idJeune, situations, conseillers }: HistoriqueProps) {
   useMatomo(tracking)
 
   useEffect(() => {
-    if (conseiller && !currentTab) {
+    if (!currentTab) {
       setCurrentTab(
-        conseiller?.structure === StructureConseiller.MILO
+        conseiller.structure === StructureConseiller.MILO
           ? Onglet.SITUATIONS
           : Onglet.CONSEILLERS
       )
     }
-  }, [conseiller, currentTab])
+  }, [currentTab])
 
   useEffect(() => {
     if (currentTab) {
@@ -68,7 +68,7 @@ function Historique({ idJeune, situations, conseillers }: HistoriqueProps) {
   return (
     <>
       <TabList className='mt-10'>
-        {conseiller?.structure === StructureConseiller.MILO && (
+        {conseiller.structure === StructureConseiller.MILO && (
           <Tab
             label='Situations'
             selected={currentTab === Onglet.SITUATIONS}

--- a/pages/mes-jeunes/[jeune_id]/historique.tsx
+++ b/pages/mes-jeunes/[jeune_id]/historique.tsx
@@ -7,7 +7,7 @@ import { ListeConseillersJeune } from 'components/jeune/ListeConseillersJeune'
 import { IconName } from 'components/ui/IconComponent'
 import Tab from 'components/ui/Navigation/Tab'
 import TabList from 'components/ui/Navigation/TabList'
-import { StructureConseiller } from 'interfaces/conseiller'
+import { estMilo } from 'interfaces/conseiller'
 import {
   CategorieSituation,
   ConseillerHistorique,
@@ -37,23 +37,13 @@ export enum Onglet {
 
 function Historique({ idJeune, situations, conseillers }: HistoriqueProps) {
   const [conseiller] = useConseiller()
-  const [currentTab, setCurrentTab] = useState<Onglet | undefined>()
+  const [currentTab, setCurrentTab] = useState<Onglet | undefined>(
+    estMilo(conseiller) ? Onglet.SITUATIONS : Onglet.CONSEILLERS
+  )
 
   const situationsTracking = 'Détail jeune – Situations'
   const conseillersTracking = 'Détail jeune – Historique conseillers'
   const [tracking, setTracking] = useState<string | undefined>()
-
-  useMatomo(tracking)
-
-  useEffect(() => {
-    if (!currentTab) {
-      setCurrentTab(
-        conseiller.structure === StructureConseiller.MILO
-          ? Onglet.SITUATIONS
-          : Onglet.CONSEILLERS
-      )
-    }
-  }, [currentTab])
 
   useEffect(() => {
     if (currentTab) {
@@ -65,10 +55,12 @@ function Historique({ idJeune, situations, conseillers }: HistoriqueProps) {
     }
   }, [currentTab])
 
+  useMatomo(tracking)
+
   return (
     <>
       <TabList className='mt-10'>
-        {conseiller.structure === StructureConseiller.MILO && (
+        {estMilo(conseiller) && (
           <Tab
             label='Situations'
             selected={currentTab === Onglet.SITUATIONS}

--- a/pages/mes-jeunes/[jeune_id]/indicateurs.tsx
+++ b/pages/mes-jeunes/[jeune_id]/indicateurs.tsx
@@ -35,7 +35,7 @@ function Indicateurs({ idJeune }: IndicateursProps) {
 
   // On récupère les indicateurs ici parce qu'on a besoin de la timezone du navigateur
   useEffect(() => {
-    if (conseiller && !indicateursSemaine) {
+    if (!indicateursSemaine) {
       jeunesService
         .getIndicateursJeuneComplets(
           conseiller.id,
@@ -45,14 +45,7 @@ function Indicateurs({ idJeune }: IndicateursProps) {
         )
         .then(setIndicateursSemaine)
     }
-  }, [
-    conseiller,
-    idJeune,
-    debutSemaine,
-    finSemaine,
-    indicateursSemaine,
-    jeunesService,
-  ])
+  }, [idJeune, debutSemaine, finSemaine, indicateursSemaine, jeunesService])
 
   return (
     <div>

--- a/pages/mes-jeunes/[jeune_id]/rendez-vous-passes.tsx
+++ b/pages/mes-jeunes/[jeune_id]/rendez-vous-passes.tsx
@@ -25,7 +25,7 @@ function RendezVousPasses({ beneficiaire, rdvs }: RendezVousPassesProps) {
   return (
     <TableauRdv
       rdvs={rdvs}
-      idConseiller={conseiller?.id ?? ''}
+      idConseiller={conseiller.id}
       beneficiaireUnique={beneficiaire}
       additionalColumns='Présent'
     />

--- a/pages/mes-jeunes/edition-rdv.tsx
+++ b/pages/mes-jeunes/edition-rdv.tsx
@@ -196,7 +196,7 @@ function EditionRdv({
   }
 
   function recupererJeunesDeLEtablissement() {
-    if (conseiller?.agence?.id) {
+    if (conseiller.agence?.id) {
       return jeunesService.getJeunesDeLEtablissement(conseiller.agence.id)
     }
     return Promise.resolve([])
@@ -355,7 +355,7 @@ function EditionRdv({
           setFormHasBeneficiaireAutrePortefeuille
         }
         conseillerIsCreator={
-          !evenement || conseiller?.id === evenement.createur.id
+          !evenement || conseiller.id === evenement.createur.id
         }
         conseiller={conseiller}
         onChanges={setHasChanges}

--- a/pages/mes-jeunes/listes-de-diffusion.tsx
+++ b/pages/mes-jeunes/listes-de-diffusion.tsx
@@ -43,7 +43,7 @@ function ListesDiffusion({ listesDiffusion }: ListesDiffusionProps) {
     const nouvelOrdre = tri === ALPHABETIQUE ? INVERSE : ALPHABETIQUE
     setTri(nouvelOrdre)
     trackEvent({
-      structure: conseiller!.structure,
+      structure: conseiller.structure,
       categorie: 'Listes de diffusion',
       action: 'Tri',
       nom: nouvelOrdre,

--- a/pages/pilotage.tsx
+++ b/pages/pilotage.tsx
@@ -224,7 +224,7 @@ function Pilotage({ actions, animationsCollectives, onglet }: PilotageProps) {
         >
           {!animationsCollectivesAffichees && (
             <EncartAgenceRequise
-              structureConseiller={conseiller.structure}
+              conseiller={conseiller}
               onAgenceChoisie={renseignerAgence}
               getAgences={referentielService.getAgencesClientSide.bind(
                 referentielService

--- a/pages/pilotage.tsx
+++ b/pages/pilotage.tsx
@@ -85,7 +85,7 @@ function Pilotage({ actions, animationsCollectives, onglet }: PilotageProps) {
     metadonnees: MetadonneesPagination
   }> {
     const result = await actionsService.getActionsAQualifierClientSide(
-      conseiller!.id,
+      conseiller.id,
       page
     )
 
@@ -99,7 +99,7 @@ function Pilotage({ actions, animationsCollectives, onglet }: PilotageProps) {
   }> {
     const result =
       await evenementsService.getAnimationsCollectivesACloreClientSide(
-        conseiller!.agence!.id!,
+        conseiller.agence!.id!,
         page
       )
 
@@ -112,7 +112,7 @@ function Pilotage({ actions, animationsCollectives, onglet }: PilotageProps) {
     nom: string
   }): Promise<void> {
     await conseillerService.modifierAgence(agence)
-    setConseiller({ ...conseiller!, agence })
+    setConseiller({ ...conseiller, agence })
     setTrackingLabel(pageTracking + ' - Succès ajout agence')
   }
 
@@ -139,7 +139,7 @@ function Pilotage({ actions, animationsCollectives, onglet }: PilotageProps) {
   }
 
   useEffect(() => {
-    if (conseiller?.agence?.id && !animationsCollectivesAffichees) {
+    if (conseiller.agence?.id && !animationsCollectivesAffichees) {
       evenementsService
         .getAnimationsCollectivesACloreClientSide(conseiller.agence.id, 1)
         .then((result) => {
@@ -150,7 +150,7 @@ function Pilotage({ actions, animationsCollectives, onglet }: PilotageProps) {
           setTotalAnimationsCollectives(result.metadonnees.nombreTotal)
         })
     }
-  }, [conseiller?.agence?.id])
+  }, [conseiller.agence?.id])
 
   useMatomo(trackingLabel)
 
@@ -167,7 +167,7 @@ function Pilotage({ actions, animationsCollectives, onglet }: PilotageProps) {
               <span className='text-base-bold'> À qualifier</span>
             </dd>
           </div>
-          {conseiller?.agence?.id && (
+          {conseiller.agence?.id && (
             <div>
               <dt className='text-base-bold'>Les animations</dt>
               <dd className='mt-2 rounded-base px-3 py-2 bg-primary_lighten text-primary_darken'>
@@ -190,9 +190,7 @@ function Pilotage({ actions, animationsCollectives, onglet }: PilotageProps) {
         />
         <Tab
           label='Animations à clore'
-          count={
-            conseiller?.agence?.id ? totalAnimationsCollectives : undefined
-          }
+          count={conseiller.agence?.id ? totalAnimationsCollectives : undefined}
           selected={currentTab === Onglet.ANIMATIONS_COLLECTIVES}
           controls='liste-animations-collectives-a-clore'
           onSelectTab={() => switchTab(Onglet.ANIMATIONS_COLLECTIVES)}
@@ -224,7 +222,7 @@ function Pilotage({ actions, animationsCollectives, onglet }: PilotageProps) {
           id='liste-animations-collectives-a-clore'
           className='mt-8 pb-8 border-b border-primary_lighten'
         >
-          {!animationsCollectivesAffichees && conseiller && (
+          {!animationsCollectivesAffichees && (
             <EncartAgenceRequise
               structureConseiller={conseiller.structure}
               onAgenceChoisie={renseignerAgence}

--- a/pages/profil.tsx
+++ b/pages/profil.tsx
@@ -36,7 +36,6 @@ function Profil({ referentielAgences }: ProfilProps) {
   const [trackingLabel, setTrackingLabel] = useState<string>('Profil')
 
   const labelAgence = useMemo(() => {
-    if (!conseiller) return ''
     return conseiller.structure === StructureConseiller.MILO
       ? 'Mission Locale'
       : 'agence'
@@ -44,11 +43,11 @@ function Profil({ referentielAgences }: ProfilProps) {
 
   async function toggleNotificationsSonores(e: ChangeEvent<HTMLInputElement>) {
     const conseillerMisAJour = {
-      ...conseiller!,
+      ...conseiller,
       notificationsSonores: e.target.checked,
     }
     await conseillerService.modifierNotificationsSonores(
-      conseiller!.id,
+      conseiller.id,
       conseillerMisAJour.notificationsSonores
     )
     setConseiller(conseillerMisAJour)
@@ -59,13 +58,13 @@ function Profil({ referentielAgences }: ProfilProps) {
     nom: string
   }): Promise<void> {
     await conseillerService.modifierAgence(agence)
-    setConseiller({ ...conseiller!, agence })
+    setConseiller({ ...conseiller, agence })
     setTrackingLabel('Profil - Succès ajout agence')
   }
 
   function trackContacterSupportClick() {
     trackEvent({
-      structure: conseiller!.structure,
+      structure: conseiller.structure,
       categorie: 'Contact Support',
       action: 'Profil',
       nom: '',
@@ -76,126 +75,119 @@ function Profil({ referentielAgences }: ProfilProps) {
 
   return (
     <>
-      {conseiller && (
-        <>
-          <section className='border border-solid rounded-base w-full p-4 border-grey_100 mb-8'>
-            <h2 className='text-m-bold text-grey_800 mb-4'>Informations</h2>
-            <h3 className='text-base-bold'>
-              {conseiller.firstName} {conseiller.lastName}
-            </h3>
-            <dl className='mt-3'>
-              {conseiller.email && (
-                <div>
-                  <dt className='mt-2 inline text-base-regular'>
-                    Votre e-mail :
-                  </dt>
-                  <dd className='ml-2 inline'>
-                    <Email email={conseiller.email} />
-                  </dd>
-                </div>
-              )}
+      <section className='border border-solid rounded-base w-full p-4 border-grey_100 mb-8'>
+        <h2 className='text-m-bold text-grey_800 mb-4'>Informations</h2>
+        <h3 className='text-base-bold'>
+          {conseiller.firstName} {conseiller.lastName}
+        </h3>
+        <dl className='mt-3'>
+          {conseiller.email && (
+            <div>
+              <dt className='mt-2 inline text-base-regular'>Votre e-mail :</dt>
+              <dd className='ml-2 inline'>
+                <Email email={conseiller.email} />
+              </dd>
+            </div>
+          )}
 
-              {conseiller.agence && (
-                <div>
-                  <dt className='mt-2 inline text-base-regular'>
-                    Votre {labelAgence} :
-                  </dt>
-                  <dd className='ml-2 inline text-base-bold'>
-                    {conseiller.agence.nom}
-                  </dd>
-                </div>
-              )}
-            </dl>
+          {conseiller.agence && (
+            <div>
+              <dt className='mt-2 inline text-base-regular'>
+                Votre {labelAgence} :
+              </dt>
+              <dd className='ml-2 inline text-base-bold'>
+                {conseiller.agence.nom}
+              </dd>
+            </div>
+          )}
+        </dl>
 
-            {conseiller.structure === StructureConseiller.MILO && (
-              <>
-                {conseiller.agence && (
-                  <div className='mt-4'>
-                    <p>
-                      Vous avez besoin de modifier votre Mission Locale de
-                      référence ?
-                    </p>
+        {conseiller.structure === StructureConseiller.MILO && (
+          <>
+            {conseiller.agence && (
+              <div className='mt-4'>
+                <p>
+                  Vous avez besoin de modifier votre Mission Locale de référence
+                  ?
+                </p>
 
-                    <p className='flex'>
-                      Pour ce faire merci de&nbsp;
-                      <span
-                        className={'text-primary_darken hover:text-primary'}
-                      >
-                        <ExternalLink
-                          href={'mailto:' + process.env.SUPPORT_MAIL}
-                          label={'contacter le support'}
-                          iconName={IconName.Email}
-                          onClick={trackContacterSupportClick}
-                        />
-                      </span>
-                    </p>
-                  </div>
-                )}
-
-                {!conseiller.agence && (
-                  <RenseignementAgenceMissionLocaleForm
-                    referentielAgences={referentielAgences}
-                    onAgenceChoisie={selectAgence}
-                    onContacterSupport={trackContacterSupportClick}
-                    container={FormContainer.PAGE}
-                  />
-                )}
-              </>
+                <p className='flex'>
+                  Pour ce faire merci de&nbsp;
+                  <span className={'text-primary_darken hover:text-primary'}>
+                    <ExternalLink
+                      href={'mailto:' + process.env.SUPPORT_MAIL}
+                      label={'contacter le support'}
+                      iconName={IconName.Email}
+                      onClick={trackContacterSupportClick}
+                    />
+                  </span>
+                </p>
+              </div>
             )}
-          </section>
-          <section className='border border-solid rounded-base w-full p-4 border-grey_100 mb-8'>
-            <h2 className='text-m-bold text-grey_800 mb-4'>Notifications</h2>
-            <div className='flex items-center flex-wrap layout_m:flex-nowrap'>
-              <label htmlFor='notificationSonore' className='mr-4'>
-                Recevoir des notifications sonores pour la réception de nouveaux
-                messages
-              </label>
-              <Switch
-                id='notificationSonore'
-                checkedLabel='Activé'
-                uncheckedLabel='Désactivé'
-                checked={conseiller.notificationsSonores}
-                onChange={toggleNotificationsSonores}
+
+            {!conseiller.agence && (
+              <RenseignementAgenceMissionLocaleForm
+                referentielAgences={referentielAgences}
+                onAgenceChoisie={selectAgence}
+                onContacterSupport={trackContacterSupportClick}
+                container={FormContainer.PAGE}
               />
-            </div>
-          </section>
-          <section className='border border-solid rounded-base w-full p-4 border-grey_100 mb-8'>
-            <h2 className='text-m-bold text-grey_800 mb-4'>
-              Application CEJ jeune - mode démo
-            </h2>
-            <p className='mb-4'>
-              Le mode démo vous permet de visualiser l’application CEJ utilisée
-              par vos bénéficiaires.
-            </p>
-            <p className='mb-4'>
-              Pour accéder au mode démo, vous devez télécharger l’application
-              sur le store de votre choix, l’ouvrir puis
-              <b> appuyer 3 fois sur le logo </b>“Contrat d’Engagement Jeune”
-              visible sur la page de connexion.
-            </p>
-            <p>
-              L’application est disponible sur Google Play Store et sur l’App
-              Store.
-            </p>
-            <div className='flex justify-evenly mt-8'>
-              <div className='flex flex-col items-center'>
-                <QrcodeAppStore
-                  focusable='false'
-                  aria-label='QR code pour l’App Store'
-                />
-                <p className='text-s-bold'>App Store</p>
-              </div>
-              <div className='flex flex-col items-center'>
-                <QrcodePlayStore
-                  focusable='false'
-                  aria-label='QR code pour Google Play'
-                />
-                <p className='text-s-bold'>Google Play</p>
-              </div>
-            </div>
-          </section>
-        </>
-      )}
+            )}
+          </>
+        )}
+      </section>
+
+      <section className='border border-solid rounded-base w-full p-4 border-grey_100 mb-8'>
+        <h2 className='text-m-bold text-grey_800 mb-4'>Notifications</h2>
+        <div className='flex items-center flex-wrap layout_m:flex-nowrap'>
+          <label htmlFor='notificationSonore' className='mr-4'>
+            Recevoir des notifications sonores pour la réception de nouveaux
+            messages
+          </label>
+          <Switch
+            id='notificationSonore'
+            checkedLabel='Activé'
+            uncheckedLabel='Désactivé'
+            checked={conseiller.notificationsSonores}
+            onChange={toggleNotificationsSonores}
+          />
+        </div>
+      </section>
+
+      <section className='border border-solid rounded-base w-full p-4 border-grey_100 mb-8'>
+        <h2 className='text-m-bold text-grey_800 mb-4'>
+          Application CEJ jeune - mode démo
+        </h2>
+        <p className='mb-4'>
+          Le mode démo vous permet de visualiser l’application CEJ utilisée par
+          vos bénéficiaires.
+        </p>
+        <p className='mb-4'>
+          Pour accéder au mode démo, vous devez télécharger l’application sur le
+          store de votre choix, l’ouvrir puis
+          <b> appuyer 3 fois sur le logo </b>“Contrat d’Engagement Jeune”
+          visible sur la page de connexion.
+        </p>
+        <p>
+          L’application est disponible sur Google Play Store et sur l’App Store.
+        </p>
+        <div className='flex justify-evenly mt-8'>
+          <div className='flex flex-col items-center'>
+            <QrcodeAppStore
+              focusable='false'
+              aria-label='QR code pour l’App Store'
+            />
+            <p className='text-s-bold'>App Store</p>
+          </div>
+          <div className='flex flex-col items-center'>
+            <QrcodePlayStore
+              focusable='false'
+              aria-label='QR code pour Google Play'
+            />
+            <p className='text-s-bold'>Google Play</p>
+          </div>
+        </div>
+      </section>
     </>
   )
 }

--- a/pages/profil.tsx
+++ b/pages/profil.tsx
@@ -1,6 +1,6 @@
 import { withTransaction } from '@elastic/apm-rum-react'
 import { GetServerSideProps } from 'next'
-import React, { ChangeEvent, useMemo, useState } from 'react'
+import React, { ChangeEvent, useState } from 'react'
 
 import QrcodeAppStore from '../assets/images/qrcode_app_store.svg'
 import QrcodePlayStore from '../assets/images/qrcode_play_store.svg'
@@ -12,7 +12,7 @@ import {
 import { Switch } from 'components/ui/Form/Switch'
 import IconComponent, { IconName } from 'components/ui/IconComponent'
 import ExternalLink from 'components/ui/Navigation/ExternalLink'
-import { StructureConseiller } from 'interfaces/conseiller'
+import { estMilo, StructureConseiller } from 'interfaces/conseiller'
 import { PageProps } from 'interfaces/pageProps'
 import { Agence } from 'interfaces/referentiel'
 import { ConseillerService } from 'services/conseiller.service'
@@ -35,11 +35,8 @@ function Profil({ referentielAgences }: ProfilProps) {
   const [conseiller, setConseiller] = useConseiller()
   const [trackingLabel, setTrackingLabel] = useState<string>('Profil')
 
-  const labelAgence = useMemo(() => {
-    return conseiller.structure === StructureConseiller.MILO
-      ? 'Mission Locale'
-      : 'agence'
-  }, [conseiller])
+  const conseillerEstMilo = estMilo(conseiller)
+  const labelAgence = conseillerEstMilo ? 'Mission Locale' : 'agence'
 
   async function toggleNotificationsSonores(e: ChangeEvent<HTMLInputElement>) {
     const conseillerMisAJour = {
@@ -102,7 +99,7 @@ function Profil({ referentielAgences }: ProfilProps) {
           )}
         </dl>
 
-        {conseiller.structure === StructureConseiller.MILO && (
+        {conseillerEstMilo && (
           <>
             {conseiller.agence && (
               <div className='mt-4'>

--- a/tests/components/DetailsJeune.test.tsx
+++ b/tests/components/DetailsJeune.test.tsx
@@ -2,6 +2,7 @@ import { screen } from '@testing-library/dom'
 import userEvent from '@testing-library/user-event'
 
 import { DetailsJeune } from 'components/jeune/DetailsJeune'
+import { unConseiller } from 'fixtures/conseiller'
 import { unDetailJeune } from 'fixtures/jeune'
 import { mockedJeunesService } from 'fixtures/services'
 import { StructureConseiller } from 'interfaces/conseiller'
@@ -31,7 +32,7 @@ describe('<DetailsJeune>', () => {
     renderWithContexts(
       <DetailsJeune
         jeune={jeune}
-        structureConseiller={StructureConseiller.MILO}
+        conseiller={unConseiller({ structure: StructureConseiller.MILO })}
         onDossierMiloClick={() => {}}
       />,
       { customDependances: { jeunesService } }
@@ -61,7 +62,7 @@ describe('<DetailsJeune>', () => {
     renderWithContexts(
       <DetailsJeune
         jeune={jeune}
-        structureConseiller={StructureConseiller.MILO}
+        conseiller={unConseiller({ structure: StructureConseiller.MILO })}
         onDossierMiloClick={() => {}}
       />,
       { customDependances: { jeunesService } }
@@ -79,7 +80,7 @@ describe('<DetailsJeune>', () => {
     renderWithContexts(
       <DetailsJeune
         jeune={jeune}
-        structureConseiller={StructureConseiller.MILO}
+        conseiller={unConseiller({ structure: StructureConseiller.MILO })}
         onDossierMiloClick={() => {}}
       />,
       { customDependances: { jeunesService } }
@@ -101,7 +102,7 @@ describe('<DetailsJeune>', () => {
         renderWithContexts(
           <DetailsJeune
             jeune={jeune}
-            structureConseiller={StructureConseiller.MILO}
+            conseiller={unConseiller({ structure: StructureConseiller.MILO })}
             onDossierMiloClick={() => {}}
           />,
           { customDependances: { jeunesService } }
@@ -124,7 +125,9 @@ describe('<DetailsJeune>', () => {
           renderWithContexts(
             <DetailsJeune
               jeune={jeune}
-              structureConseiller={StructureConseiller.POLE_EMPLOI}
+              conseiller={unConseiller({
+                structure: StructureConseiller.POLE_EMPLOI,
+              })}
               onDossierMiloClick={() => {}}
             />,
             { customDependances: { jeunesService } }
@@ -151,7 +154,9 @@ describe('<DetailsJeune>', () => {
         renderWithContexts(
           <DetailsJeune
             jeune={jeune}
-            structureConseiller={StructureConseiller.POLE_EMPLOI}
+            conseiller={unConseiller({
+              structure: StructureConseiller.POLE_EMPLOI,
+            })}
             onDossierMiloClick={() => {}}
           />,
           {
@@ -232,7 +237,9 @@ describe('<DetailsJeune>', () => {
         renderWithContexts(
           <DetailsJeune
             jeune={jeune}
-            structureConseiller={StructureConseiller.POLE_EMPLOI}
+            conseiller={unConseiller({
+              structure: StructureConseiller.POLE_EMPLOI,
+            })}
             onDossierMiloClick={() => {}}
           />,
           {
@@ -314,7 +321,7 @@ describe('<DetailsJeune>', () => {
       renderWithContexts(
         <DetailsJeune
           jeune={jeune}
-          structureConseiller={StructureConseiller.MILO}
+          conseiller={unConseiller({ structure: StructureConseiller.MILO })}
           onDossierMiloClick={() => {}}
         />,
         { customDependances: { jeunesService } }

--- a/tests/integration/NotificationsSonores.test.tsx
+++ b/tests/integration/NotificationsSonores.test.tsx
@@ -1,4 +1,5 @@
 import { act, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { DateTime } from 'luxon'
 import { useRouter } from 'next/router'
 
@@ -132,12 +133,11 @@ function renderWithNotificationsSonores(
 }
 
 async function toggleNotifications() {
-  const toggleNotifications = screen.getByRole<HTMLInputElement>('checkbox', {
-    name: /notifications sonores/,
-  })
-  await act(async () => {
-    toggleNotifications.click()
-  })
+  await userEvent.click(
+    screen.getByRole<HTMLInputElement>('checkbox', {
+      name: /notifications sonores/,
+    })
+  )
 }
 
 async function unNouveauMessageArrive(

--- a/utils/analytics/useMatomo.tsx
+++ b/utils/analytics/useMatomo.tsx
@@ -1,10 +1,10 @@
 import { useEffect } from 'react'
 
 import { trackPage, userStructureDimensionString } from 'utils/analytics/matomo'
-import { useConseiller } from 'utils/conseiller/conseillerContext'
+import { useConseillerPotentiellementPasRecupere } from 'utils/conseiller/conseillerContext'
 
 function useMatomo(title: string | undefined) {
-  const [conseiller] = useConseiller()
+  const [conseiller] = useConseillerPotentiellementPasRecupere()
 
   useEffect(() => {
     if (!title) {

--- a/utils/conseiller/conseillerContext.tsx
+++ b/utils/conseiller/conseillerContext.tsx
@@ -22,27 +22,24 @@ export function ConseillerProvider({
   )
 }
 
-export function useConseiller(): ConseillerState {
+export function useConseillerPotentiellementPasRecupere(): ConseillerState {
   const conseillerContext = useContext(ConseillerContext)
   if (!conseillerContext) {
-    throw new Error('useConseiller must be used within ConseillerProvider')
+    throw new Error(
+      'useConseillerPotentiellementPasRecupere must be used within ConseillerProvider'
+    )
   }
   return conseillerContext
 }
 
-export function useForcedConseiller(): [
+export function useConseiller(): [
   Conseiller,
   (credentials: Conseiller) => void
 ] {
-  const conseillerContext = useContext(ConseillerContext)
-  if (!conseillerContext) {
-    throw new Error('useConseiller must be used within ConseillerProvider')
-  }
-
-  const [conseiller, setConseiller] = conseillerContext
+  const [conseiller, setConseiller] = useConseillerPotentiellementPasRecupere()
   if (!conseiller) {
     throw new Error(
-      'useForcedConseiller must be used within Layout where conseiller is initialized'
+      'useConseiller must be used within Layout where conseiller is initialized'
     )
   }
 

--- a/utils/conseiller/conseillerContext.tsx
+++ b/utils/conseiller/conseillerContext.tsx
@@ -29,3 +29,22 @@ export function useConseiller(): ConseillerState {
   }
   return conseillerContext
 }
+
+export function useForcedConseiller(): [
+  Conseiller,
+  (credentials: Conseiller) => void
+] {
+  const conseillerContext = useContext(ConseillerContext)
+  if (!conseillerContext) {
+    throw new Error('useConseiller must be used within ConseillerProvider')
+  }
+
+  const [conseiller, setConseiller] = conseillerContext
+  if (!conseiller) {
+    throw new Error(
+      'useForcedConseiller must be used within Layout where conseiller is initialized'
+    )
+  }
+
+  return [conseiller, setConseiller]
+}

--- a/utils/hooks/useLeanBeWidget.ts
+++ b/utils/hooks/useLeanBeWidget.ts
@@ -1,18 +1,17 @@
 import { useEffect } from 'react'
 
-import { StructureConseiller } from 'interfaces/conseiller'
+import { Conseiller, estPoleEmploi } from 'interfaces/conseiller'
 
 export namespace LeanBe {
   export const MILO_WIDGET_ID = '6311adec35e9790013bdfdf6'
   export const PE_WIDGET_ID = '6311e7ab83faaf001224e4e8'
 }
 
-export function useLeanBeWidget(structure: StructureConseiller | undefined) {
+export function useLeanBeWidget(conseiller: Conseiller) {
   useEffect(() => {
-    const widgetId =
-      structure === StructureConseiller.POLE_EMPLOI
-        ? LeanBe.PE_WIDGET_ID
-        : LeanBe.MILO_WIDGET_ID
+    const widgetId = estPoleEmploi(conseiller)
+      ? LeanBe.PE_WIDGET_ID
+      : LeanBe.MILO_WIDGET_ID
     const script = document.createElement('script')
     script.append(
       'window.SGBFWidgetLoader = window.SGBFWidgetLoader || {ids:[],call:function(w,d,s,l,id) {\n' +


### PR DESCRIPTION
On utilise souvent `conseiller?.structure === ` pour vérifier qu'un conseiller est ou n'est pas de telle ou telle structure.
Or, le temps que le conseiller soit récupéré et chargé dans le `useConseiller`, `conseiller?.structure` est _falsy_.
Ça fausse du coup certains check.
Par exemple, dans la fiche du jeune, on ne veut charger l'agenda que si le conseiller n'est pas Pole Emploi. Du coup si on arrive directement sur la page (raffraichissement par exemple), `conseiller?.structure === POLE_EMPLOI` est _falsy_ et on appelle l'API pour récupérer l'agenda avant même d'avoir récupéré et vérifié le conseiller.

**Solution :**
- loader dans le `<Layout>` tant que le conseiller n'est pas chargé qui bloque l'affichage de la page
- utiliser `useForcedConseiller` plutôt que `useConseiller` qui contrôle la présence du conseiller