### PR TITLE
feat: disconnect on server-side 401/403

### DIFF
--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -12,7 +12,13 @@ const CustomError: NextPage<ErrorProps> = ({ statusCode, message }) => (
 
 CustomError.getInitialProps = ({ req, res, err }) => {
   let props: ErrorProps
+
   if (res) {
+    if (err && err.statusCode === 401) {
+      res.writeHead(302, { Location: '/api/auth/federated-logout' })
+      res.end()
+    }
+
     props = { statusCode: res.statusCode, message: res.statusMessage }
   } else if (err) {
     props = { statusCode: err.statusCode, message: err.message }

--- a/pages/mes-jeunes/[jeune_id]/favoris.tsx
+++ b/pages/mes-jeunes/[jeune_id]/favoris.tsx
@@ -63,7 +63,7 @@ export const getServerSideProps: GetServerSideProps<FavorisProps> = async (
       },
     }
   } catch (error) {
-    if (error instanceof ApiError && error.status === 403) {
+    if (error instanceof ApiError && error.statusCode === 403) {
       return { redirect: { destination: '/mes-jeunes', permanent: false } }
     }
     throw error

--- a/services/conseiller.service.ts
+++ b/services/conseiller.service.ts
@@ -125,7 +125,7 @@ async function getConseiller(
     )
     return jsonToConseiller(conseillerJson, user)
   } catch (e) {
-    if (e instanceof ApiError) {
+    if (e instanceof ApiError && e.statusCode === 404) {
       return undefined
     }
     throw e

--- a/services/evenements.service.ts
+++ b/services/evenements.service.ts
@@ -105,7 +105,7 @@ export async function getDetailsEvenement(
     )
     return jsonToEvenement(rdvJson)
   } catch (e) {
-    if (e instanceof ApiError && e.status === 404) {
+    if (e instanceof ApiError && e.statusCode === 404) {
       return undefined
     }
     throw e

--- a/services/immersions.service.ts
+++ b/services/immersions.service.ts
@@ -34,7 +34,7 @@ export async function getImmersionServerSide(
     )
     return jsonToDetailImmersion(immersionJson)
   } catch (e) {
-    if (e instanceof ApiError && e.status === 404) {
+    if (e instanceof ApiError && e.statusCode === 404) {
       return undefined
     }
     throw e

--- a/services/jeunes.service.ts
+++ b/services/jeunes.service.ts
@@ -82,7 +82,7 @@ export async function getJeuneDetails(
     )
     return jsonToDetailJeune(jeune)
   } catch (e) {
-    if (e instanceof ApiError && e.status === 404) {
+    if (e instanceof ApiError && e.statusCode === 404) {
       return undefined
     }
     throw e
@@ -134,7 +134,7 @@ export async function getIdJeuneMilo(
     )
     return id
   } catch (e) {
-    if (e instanceof ApiError && e.status === 404) {
+    if (e instanceof ApiError && e.statusCode === 404) {
       return undefined
     }
     throw e
@@ -192,7 +192,7 @@ export async function getMetadonneesFavorisJeune(
     }>(`/jeunes/${idJeune}/favoris/metadonnees`, accessToken)
     return jsonToMetadonneesFavoris(metadonneesFavoris)
   } catch (e) {
-    if (e instanceof ApiError && e.status === 404) {
+    if (e instanceof ApiError && e.statusCode === 404) {
       return undefined
     }
 
@@ -327,7 +327,7 @@ async function getConseillersDuJeune(
       )
       return historique.map(toConseillerHistorique)
     } catch (e) {
-      if (e instanceof ApiError && e.status === 404) {
+      if (e instanceof ApiError && e.statusCode === 404) {
         return []
       }
       throw e

--- a/services/offres-emploi.service.ts
+++ b/services/offres-emploi.service.ts
@@ -67,7 +67,7 @@ async function getOffreEmploi(idOffreEmploi: string, accessToken: string) {
     )
     return offreEmploiJson && jsonToDetailOffreEmploi(offreEmploiJson)
   } catch (e) {
-    if (e instanceof ApiError && e.status === 404) {
+    if (e instanceof ApiError && e.statusCode === 404) {
       return undefined
     }
     throw e

--- a/services/services-civiques.service.ts
+++ b/services/services-civiques.service.ts
@@ -73,7 +73,7 @@ async function getServiceCivique(
       )
     return serviceCiviqueJson
   } catch (e) {
-    if (e instanceof ApiError && e.status === 404) {
+    if (e instanceof ApiError && e.statusCode === 404) {
       return undefined
     }
     throw e

--- a/utils/httpClient.ts
+++ b/utils/httpClient.ts
@@ -59,7 +59,10 @@ async function handleHttpError(response: Response): Promise<void> {
 export class ApiError implements Error {
   name = 'API_ERROR'
 
-  constructor(readonly status: number, readonly message: string) {}
+  constructor(
+    readonly statusCode: number,
+    readonly message: string
+  ) {}
 }
 
 export class UnexpectedError implements Error {


### PR DESCRIPTION
C'est pas hyper satisfaisant parce que si l'exception est interceptée (par exemple dans `OngletAgendaConseiller`.`initEvenementsPeriode`) on affiche pas la page `_error` et donc pas de déconnexion :thinking: Mais je sais pas trop comment faire mieux.

Faut vraiment qu'on migre vers le nouveau pattern router de Next (https://nextjs.org/docs/app/building-your-application/upgrading/app-router-migration) parce que je pense que ça peut nous faciliter ce genre de trucs, par exemple avec de la redirection _server-side_ (https://nextjs.org/docs/app/api-reference/functions/redirect)